### PR TITLE
ImageFetcher: protect against missing images and inconsistent names

### DIFF
--- a/assets/www/js/api.js
+++ b/assets/www/js/api.js
@@ -157,11 +157,19 @@ define(['jquery'], function() {
 		this.height = height;
 	}
 
+	ImageFetcher.prototype.addDeferred = function( title, deferred ) {
+		this.deferreds[ title.replace(/ /g, '_') ] = deferred;
+	};
+
+	ImageFetcher.prototype.getDeferred = function( title ) {
+		return this.deferreds[ title.replace(/ /g, '_') ];
+	};
+
 	ImageFetcher.prototype.request = function(filename) {
 		var d = $.Deferred();
 		var title = 'File:' + filename;
 		this.titles.push(title);
-		this.deferreds[title] = d;
+		this.addDeferred( title, d );
 		return d.promise();
 	};
 
@@ -200,7 +208,12 @@ define(['jquery'], function() {
 				}
 				if(page.imageinfo) {
 					var imageinfo = page.imageinfo[0];
-					that.deferreds[title].resolve(imageinfo);
+					deferred = that.getDeferred( title );
+					if( deferred ) {
+						deferred.resolve( imageinfo );
+					} else {
+						console.log( 'Failed to locate deferred image with title ' + title );
+					}
 				}
 			});
 		});

--- a/assets/www/js/monuments.js
+++ b/assets/www/js/monuments.js
@@ -82,11 +82,13 @@ define(['jquery'], function($) {
 
 	Monument.prototype.requestThumbnail = function(imageFetcher) {
 		var d = $.Deferred();
-		imageFetcher.request(this.image).done(function(imageinfo) {
-			d.resolve(imageinfo);
-		}).fail(function(err) {
-			d.reject.apply(d, arguments);
-		});
+		if( this.image ) {
+			imageFetcher.request( this.image ).done( function( imageinfo ) {
+				d.resolve( imageinfo );
+			} ).fail( function( err ) {
+				d.reject.apply( d, arguments );
+			} );
+		}
 		return d.promise();
 	};
 


### PR DESCRIPTION
it seems spaces and _ are both used for naming files so the ImageFetcher
sometimes doesn't find an image and throws an exception

Also not all monuments seem to have images so if no image don't try to
request it at all
