### PR TITLE
deal with upload errors

### DIFF
--- a/assets/www/index.html
+++ b/assets/www/index.html
@@ -198,6 +198,23 @@
 		</div>
 	</div>
 
+	<div class="popup-container-container" id="error-page">
+		<div class="popup-container">
+			<div class="popup">
+				<header>
+					<h2><msg key="failure-heading" /></h2>
+				</header>
+				<div class="content">
+					<p>
+						<msg key="failure-details" />
+					</p>
+					<textarea></textarea>
+					<button class="back">cancel</button>
+					</div>
+			</div>
+		</div>
+	</div>
+
 	<div class="popup-container-container" id="upload-progress-page">
 		<div class="popup-container">
 			<div class="popup">

--- a/assets/www/js/api.js
+++ b/assets/www/js/api.js
@@ -103,7 +103,9 @@ define(['jquery'], function() {
 				console.log("Response = " + r.response);
 				console.log("Sent = " + r.bytesSent);
 				var data = JSON.parse(r.response);
-				if (data.upload.result === 'Success') {
+				if( data.error ) {
+					d.reject( data );
+				} else if ( data && data.upload && data.upload.result === 'Success' ) {
 					d.resolve(data.upload.filekey);
 				} else {
 					d.reject(data);

--- a/assets/www/js/app.js
+++ b/assets/www/js/app.js
@@ -91,8 +91,8 @@ require( [ 'jquery', 'l10n', 'geo', 'api', 'templates', 'monuments', 'preference
 	function showPage(pageName) {
 		addToHistory( pageName );
 		var $page = $("#" + pageName); 
+		$('.page, .popup-container-container').hide(); // hide existing popups
 		if(!$page.hasClass('popup-container-container')) {
-			$('.page, .popup-container-container').hide();
 			curPageName = pageName;
 		}
 		$page.show();
@@ -168,6 +168,10 @@ require( [ 'jquery', 'l10n', 'geo', 'api', 'templates', 'monuments', 'preference
 		});
 	}
 
+	function displayError( heading, text ) {
+		showPage( 'error-page' );
+		$( '#error-page textarea' ).val( heading + ':\n' + text );
+	}
 
 	function showPhotoConfirmation(fileUrl) {
 		var uploadConfirmTemplate = templates.getTemplate('upload-confirm-template');
@@ -188,7 +192,16 @@ require( [ 'jquery', 'l10n', 'geo', 'api', 'templates', 'monuments', 'preference
 						showPage('detail-page');
 					}, 2 * 1000);
 				});
-			});
+			}).fail( function( data ) {
+				var code, info;
+				if( data.error ) {
+					code = data.error.code;
+					info = data.error.info;
+				}
+				$( '#upload-progress-state' ).html( mw.msg( 'upload-progress-failed' ) );
+				displayError( code, info );
+				console.log( 'Upload failed: ' + code );
+			} );
 		});
 		showPage('upload-confirm-page');
 	}

--- a/assets/www/messages/messages-en.properties
+++ b/assets/www/messages/messages-en.properties
@@ -18,6 +18,9 @@ filter-label=Filter:
 attribution-mapquest = Tiles courtesy <a href="http://www.mapquest.com">MapQuest</a>
 attribution-osm = Map Data (C) <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>
 
+failure-heading=Whoops!
+failure-details=Whoops! We just broke something we shouldn't have. An error message is given below
+
 detail-title=Monument details
 detail-link=Wikipedia article
 detail-address=Address
@@ -65,3 +68,4 @@ upload-progress-title=Uploading...
 upload-progress-starting=Starting upload...
 upload-progress-in-progress=Uploading in progress...
 upload-progress-done=Finished uploading!
+upload-progress-failed=The upload sadly failed


### PR DESCRIPTION
deal with 200 responses that contain error messages on a failed upload
add generic error handler for displaying these errors with cancel button
hide all existing popups when showing a page (this deals with the case where
the uploading status message popup is open and then loads the error popup)

when cancelling the error message the previous upload screen is shown hence
the update of upload message
see #21 for cancelling an upload
