### PR TITLE
Bug/38072

### DIFF
--- a/assets/www/app.css
+++ b/assets/www/app.css
@@ -331,7 +331,7 @@ button.requires-location {
 	margin-top: 100px;
 }
 
-#login-page input[state='error'] {
+#login-page input.error-input-field {
 	background-color: #FFFFE1;
 	border: 1px solid red;
 }

--- a/assets/www/app.css
+++ b/assets/www/app.css
@@ -331,6 +331,11 @@ button.requires-location {
 	margin-top: 100px;
 }
 
+#login-page input[state='error'] {
+	background-color: #FFFFE1;
+	border: 1px solid red;
+}
+
 /* Upload confirmation specific CSS */
 
 #upload-confirm-page img.preview-image {

--- a/assets/www/index.html
+++ b/assets/www/index.html
@@ -222,11 +222,8 @@
 					<h2><msg key="failure-heading" /></h2>
 				</header>
 				<div class="content">
-					<p>
-						<msg key="failure-details" />
-					</p>
-					<textarea></textarea>
-					<button class="back">cancel</button>
+					<p id="error-msg"></p>
+					<button class="back"><msg key="popup-ok"></button>
 					</div>
 			</div>
 		</div>

--- a/assets/www/index.html
+++ b/assets/www/index.html
@@ -222,8 +222,11 @@
 					<h2><msg key="failure-heading" /></h2>
 				</header>
 				<div class="content">
-					<p id="error-msg"></p>
-					<button class="back"><msg key="popup-ok"></button>
+					<p>
+						<msg key="failure-details">
+					</p>
+					<textarea></textarea>
+					<button class="back"><msg key="popup-cancel"></button>
 					</div>
 			</div>
 		</div>

--- a/assets/www/js/app.js
+++ b/assets/www/js/app.js
@@ -291,7 +291,37 @@ require( [ 'jquery', 'l10n', 'geo', 'api', 'templates', 'monuments', 'preference
 						success();
 					}, 3 * 1000 );
 				} else {
-					$( "#login-status-message" ).html( mw.msg( 'login-failed', status ) );
+					var errMsg;
+					// handle login API errors
+					// http://www.mediawiki.org/wiki/API:Login#Errors
+					switch( status ) {
+						case 'NoName': // lgname param not set
+						case 'Illegal': // an illegal username was provided
+						case 'NotExists': // username does not exist
+							errMsg = "There was something wrong with the username you entered. Please try again.";
+							break;
+						case 'EmptyPass': // didn't set the lgpass param
+						case 'WrongPass': // password is incorrect
+						case 'WrongPluginPass': // auth plugin (not MW) rejected pw
+							errMsg = "There was something wrong with the password you provided. Please try again.";
+							break;
+						case 'CreateBlocked': // IP address blocked from account creation
+						case 'Blocked': // User is blocked
+							errMsg = "The user account you are attempting to use has been blocked. Please view http://en.wikipedia.org/wiki/Wikipedia:Blocking_policy for more info.";
+							break;
+						case 'Throttled': // Attempting to login too many times in a short time
+							errMsg = "You have attempted to log in too many times in a short period of time. Please wait a litlte while and try again.";
+							break;
+						case 'mustbeposted': // login module requires a 'post' request
+						case 'NeedToken': // login token/session cookie missing
+							errMsg = "There was an internal error. Please try again in a little while. If the problem persists, please contact us.";
+							break;
+						default:
+							errMsg = "There was an error during your login attempt. Please try again.";
+							break;
+					}
+					//$( "#login-status-message" ).html( mw.msg( 'login-failed', status ) );
+					displayError( mw.msg( 'login-failed' ), errMsg );
 					fail( status );
 				}
 			}).fail( function( err, textStatus ) {

--- a/assets/www/js/app.js
+++ b/assets/www/js/app.js
@@ -233,7 +233,7 @@ require( [ 'jquery', 'l10n', 'geo', 'api', 'templates', 'monuments', 'preference
 
 	function displayError( heading, text ) {
 		showPage( 'error-page' );
-		$( '#error-msg' ).html( heading + ':<br>' + text );
+		$( '#error-page textarea' ).val( heading + ':\n' + text );
 	}
 
 	function showPhotoConfirmation(fileUrl) {
@@ -277,7 +277,7 @@ require( [ 'jquery', 'l10n', 'geo', 'api', 'templates', 'monuments', 'preference
 		var prevPage = curPageName;
 
 		function authenticate( username, password ) {
-			$( "#login-user, #login-pass" ).attr( 'state', '' );
+			$( "#login-user, #login-pass" ).removeClass( 'error-input-field' );
 			$( "#login-status" ).show();
 			$( "#login-page input" ).attr( 'disabled', true );
 			$( "#login-status-message" ).text( mw.msg( 'login-in-progress' ) );
@@ -300,13 +300,13 @@ require( [ 'jquery', 'l10n', 'geo', 'api', 'templates', 'monuments', 'preference
 						case 'Illegal': // an illegal username was provided
 						case 'NotExists': // username does not exist
 							errMsg = mw.msg( 'login-failed-username' );
-							$( "#login-user" ).attr( 'state', 'error' );
+							$( "#login-user" ).addClass( 'error-input-field' );
 							break;
 						case 'EmptyPass': // didn't set the lgpass param
 						case 'WrongPass': // password is incorrect
 						case 'WrongPluginPass': // auth plugin (not MW) rejected pw
 							errMsg = mw.msg( 'login-failed-password' );
-							$( "#login-pass" ).attr( 'state', 'error' );
+							$( "#login-pass" ).addClass( 'error-input-field' );
 							break;
 						case 'CreateBlocked': // IP address blocked from account creation
 						case 'Blocked': // User is blocked
@@ -323,12 +323,12 @@ require( [ 'jquery', 'l10n', 'geo', 'api', 'templates', 'monuments', 'preference
 							errMsg = mw.msg( 'login-failed-default' );
 							break;
 					}
-					$( "#login-status-message" ).html( '' );
+					$( "#login-status-message" ).empty();
 					displayError( mw.msg( 'login-failed'), errMsg );
 					fail( status );
 				}
 			}).fail( function( err, textStatus ) {
-				$( "#login-status-message" ).html( '' );
+				$( "#login-status-message" ).empty();
 				displayError( mw.msg( 'login-failed' ), textStatus );
 				fail( textStatus );
 			}).always( function() {

--- a/assets/www/js/app.js
+++ b/assets/www/js/app.js
@@ -277,6 +277,7 @@ require( [ 'jquery', 'l10n', 'geo', 'api', 'templates', 'monuments', 'preference
 		var prevPage = curPageName;
 
 		function authenticate( username, password ) {
+			$( "#login-user, #login-pass" ).attr( 'state', '' );
 			$( "#login-status" ).show();
 			$( "#login-page input" ).attr( 'disabled', true );
 			$( "#login-status-message" ).text( mw.msg( 'login-in-progress' ) );
@@ -298,34 +299,37 @@ require( [ 'jquery', 'l10n', 'geo', 'api', 'templates', 'monuments', 'preference
 						case 'NoName': // lgname param not set
 						case 'Illegal': // an illegal username was provided
 						case 'NotExists': // username does not exist
-							errMsg = "There was something wrong with the username you entered. Please try again.";
+							errMsg = mw.msg( 'login-failed-username' );
+							$( "#login-user" ).attr( 'state', 'error' );
 							break;
 						case 'EmptyPass': // didn't set the lgpass param
 						case 'WrongPass': // password is incorrect
 						case 'WrongPluginPass': // auth plugin (not MW) rejected pw
-							errMsg = "There was something wrong with the password you provided. Please try again.";
+							errMsg = mw.msg( 'login-failed-password' );
+							$( "#login-pass" ).attr( 'state', 'error' );
 							break;
 						case 'CreateBlocked': // IP address blocked from account creation
 						case 'Blocked': // User is blocked
-							errMsg = "The user account you are attempting to use has been blocked. Please view http://en.wikipedia.org/wiki/Wikipedia:Blocking_policy for more info.";
+							errMsg = mw.msg( 'login-failed-blocked' );
 							break;
 						case 'Throttled': // Attempting to login too many times in a short time
-							errMsg = "You have attempted to log in too many times in a short period of time. Please wait a litlte while and try again.";
+							errMsg = mw.msg( 'login-failed-throttled' );
 							break;
 						case 'mustbeposted': // login module requires a 'post' request
 						case 'NeedToken': // login token/session cookie missing
-							errMsg = "There was an internal error. Please try again in a little while. If the problem persists, please contact us.";
+							errMsg = mw.msg( 'login-failed-internal' );
 							break;
 						default:
-							errMsg = "There was an error during your login attempt. Please try again.";
+							errMsg = mw.msg( 'login-failed-default' );
 							break;
 					}
-					//$( "#login-status-message" ).html( mw.msg( 'login-failed', status ) );
-					displayError( mw.msg( 'login-failed' ), errMsg );
+					$( "#login-status-message" ).html( '' );
+					displayError( mw.msg( 'login-failed'), errMsg );
 					fail( status );
 				}
 			}).fail( function( err, textStatus ) {
-				$( "#login-status-message" ).html( mw.msg( 'login-failed', textStatus ) );
+				displayError( ms.msg( 'login-failed' ), textStatus );
+				$( "#login-status-message" ).html( '' );
 				fail( textStatus );
 			}).always( function() {
 				$( "#login-status-spinner" ).hide();

--- a/assets/www/js/app.js
+++ b/assets/www/js/app.js
@@ -233,7 +233,7 @@ require( [ 'jquery', 'l10n', 'geo', 'api', 'templates', 'monuments', 'preference
 
 	function displayError( heading, text ) {
 		showPage( 'error-page' );
-		$( '#error-page textarea' ).val( heading + ':\n' + text );
+		$( '#error-msg' ).html( heading + ':<br>' + text );
 	}
 
 	function showPhotoConfirmation(fileUrl) {
@@ -328,8 +328,8 @@ require( [ 'jquery', 'l10n', 'geo', 'api', 'templates', 'monuments', 'preference
 					fail( status );
 				}
 			}).fail( function( err, textStatus ) {
-				displayError( ms.msg( 'login-failed' ), textStatus );
 				$( "#login-status-message" ).html( '' );
+				displayError( mw.msg( 'login-failed' ), textStatus );
 				fail( textStatus );
 			}).always( function() {
 				$( "#login-status-spinner" ).hide();

--- a/assets/www/messages/messages-en.properties
+++ b/assets/www/messages/messages-en.properties
@@ -9,6 +9,7 @@ choose-campaign=Choose Campaign
 
 back=Back
 popup-cancel=Cancel
+popup-ok = OK
 
 geolocating-heading=Talking to the satellites
 geolocating-text=We're talking to some satellites to work out where in the world you are. Please be patient!

--- a/assets/www/messages/messages-en.properties
+++ b/assets/www/messages/messages-en.properties
@@ -39,7 +39,13 @@ login-title=Log in to continue
 login=Login
 login-in-progress = Logging in...
 login-success = Logged in!
-login-failed = Login failed :( $1
+login-failed = Login failed
+login-failed-username = There was something wrong with the username you entered.
+login-failed-password = There was something wrong with the password you provided.
+login-failed-blocked = The user account you are attempting to use has been blocked. Please visit http://en.wikipedia.org/wiki/Wikipedia:Blocking_policy for more info.
+login-failed-throttled = You have attempted to log in too many times in a short period of time. Please wait a litlte while and try again.
+login-failed-internal = There was an internal error. Please try again in a little while. If the problem persists, please contact us.
+login-failed-default = There was an error during your login attempt. Please try again.
 
 add-photo-title=Add a Photo
 add-photo-gallery=Choose from Gallery


### PR DESCRIPTION
Addresses https://bugzilla.wikimedia.org/show_bug.cgi?id=38072

Adds error messaging for different login API error states and switches from using the login notification area to use the displayError() popup message. Also modifies displayError() and the popup view to not use the textarea for populating the error message. Now the error message gets populated in a particular <p> tag, and the default error messaging has been removed. Not sure about the impact this will have on other displayError() uses, but I think it should be minimal and if the default error messaging is still desired, it could be prepended to the error messages in specific use cases.
