### PR TITLE
Generate the list of campaigns + license + cat information dynamically

### DIFF
--- a/assets/www/index.html
+++ b/assets/www/index.html
@@ -18,7 +18,7 @@
 	<script type="text/html" id="country-list-template">
 		<% _.each(countries, function( country ) { %>
 			<li>
-				<a class='country-search' data-campaign='<%= country.code %>' href="#"><%= country.name %></a>
+				<a class='country-search' data-campaign='<%= country.name %>' href="#"><%= country.desc %></a>
 			</li>
 		<% }); %>
 	</script>

--- a/assets/www/js/app.js
+++ b/assets/www/js/app.js
@@ -19,7 +19,7 @@ function handleOpenURL(url)
 	// TODO: do something with the url passed in.
 }
 */
-require( [ 'jquery', 'l10n', 'geo', 'api', 'templates', 'monuments', 'preferences', 'jquery.localize', 'jquery.dpr' ],
+require( [ 'jquery', 'l10n', 'geo', 'api', 'templates', 'monuments', 'preferences', 'jquery.localize', 'jquery.dpr', 'campaigns-data' ],
 	function( $, l10n, geo, Api, templates, MonumentsApi, prefs ) {
 
 	var api = new Api("https://test.wikipedia.org/w/api.php");
@@ -35,41 +35,6 @@ require( [ 'jquery', 'l10n', 'geo', 'api', 'templates', 'monuments', 'preference
 	};
 	var currentSortMethod = 'name';
 	var userLocation; // for keeping track of the user
-	var countries = [
-		{ code: 'ad', name: 'Andorra' },
-		{ code: 'at', name: 'Austria' },
-		{ code: 'be-bru', name: 'Belgium (Brussels)' },
-		{ code: 'be-vlg', name: 'Belgium (Flanders)' },
-		{ code: 'be-wal', name: 'Belgium (Wallonia)' },
-		{ code: 'by', name: 'Belarus' },
-		{ code: 'ch', name: 'Switzerland' },
-		{ code: 'de-by', name: 'Germany (Bavaria)' },
-		{ code: 'de-he', name: 'Germany (Hesse)' },
-		{ code: 'de-nrw-bm', name: 'Germany (nrw-bm)' },
-		{ code: 'de-nrw-k', name: 'Germany (nrw-k)' },
-		{ code: 'dk-bygning', name: 'Denmark (bygning)' },
-		{ code: 'dk-fortids', name: 'Denmark (fortids)' },
-		{ code: 'ee', name: 'Estonia' },
-		{ code: 'es', name: 'Spain' },
-		{ code: 'es-ct', name: 'Spain (Catalonia)' },
-		{ code: 'es-vc', name: 'Spain (Valencia)' },
-		{ code: 'fr', name: 'France' },
-		{ code: 'ie', name: 'Ireland' },
-		{ code: 'it-88', name: 'Italy (88)' },
-		{ code: 'it-bz', name: 'Italy (bz)' },
-		{ code: 'lu', name: 'Luxemburg' },
-		{ code: 'mt', name: 'Malta' },
-		{ code: 'nl', name: 'Netherlands' },
-		{ code: 'no', name: 'Norway' },
-		{ code: 'pl', name: 'Poland' },
-		{ code: 'pt', name: 'Portugal' },
-		{ code: 'ro', name: 'Romania' },
-		{ code: 'se', name: 'Sweden' },
-		{ code: 'sk', name: 'Slovakia' },
-		{ code: 'us', name: 'United States' }
-	].sort( function( a, b ) {
-		return a.name.toLowerCase() < b.name.toLowerCase() ? -1 : 1;
-	} );
 
 	var curPageName = null;
 	var curMonument = null; // Used to store state for take photo, etc
@@ -366,7 +331,7 @@ require( [ 'jquery', 'l10n', 'geo', 'api', 'templates', 'monuments', 'preference
 	function init() {
 		var timeout, name, countryCode;
 		var countriesListTemplate = templates.getTemplate('country-list-template');
-		$("#country-list").html(countriesListTemplate({countries: countries}));
+		$("#country-list").html(countriesListTemplate({countries: CAMPAIGNS}));
 		$("#country-list .country-search").click(function() {
 			countryCode = $(this).data('campaign');
 			var params = {

--- a/assets/www/js/campaigns-data.js
+++ b/assets/www/js/campaigns-data.js
@@ -1,0 +1,203 @@
+window.CAMPAIGNS = [
+    {
+        "licenses": [
+            "cc-by-sa-3.0"
+        ], 
+        "name": "ad", 
+        "categories": [
+            "Cultural heritage monuments in Andorra"
+        ], 
+        "desc": "Andorra"
+    }, 
+    {
+        "licenses": [
+            "cc-by-sa-3.0-at"
+        ], 
+        "name": "at", 
+        "categories": [
+            "Cultural heritage monuments in Austria"
+        ], 
+        "desc": "Austria"
+    }, 
+    {
+        "licenses": [
+            "cc-by-sa-3.0"
+        ], 
+        "name": "be-bru", 
+        "categories": [
+            "Cultural heritage monuments in Brussels"
+        ], 
+        "desc": "Belgium (Brussels)"
+    }, 
+    {
+        "licenses": [
+            "cc-by-sa-3.0"
+        ], 
+        "name": "be-vlg", 
+        "categories": [
+            "Onroerend erfgoed in Flanders"
+        ], 
+        "desc": "Belgium (Flanders)"
+    }, 
+    {
+        "licenses": [
+            "cc-by-sa-3.0"
+        ], 
+        "name": "be-wal", 
+        "categories": [
+            "Cultural heritage monuments in Wallonia"
+        ], 
+        "desc": "Belgium (Wallonia)"
+    }, 
+    {
+        "licenses": [
+            "cc-by-sa-3.0-ee"
+        ], 
+        "name": "ee", 
+        "categories": [
+            "Cultural heritage monuments in Estonia"
+        ], 
+        "desc": "Estonia"
+    }, 
+    {
+        "licenses": [
+            "cc-by-sa-3.0"
+        ], 
+        "name": "fr", 
+        "categories": [
+            "Monuments historiques in France"
+        ], 
+        "desc": "France"
+    }, 
+    {
+        "licenses": [
+            "cc-by-sa-3.0"
+        ], 
+        "name": "de-by", 
+        "categories": [
+            "Images from Wiki Loves Monuments 2011, DE-BY"
+        ], 
+        "desc": "Germany (Bavaria)"
+    }, 
+    {
+        "licenses": [
+            "cc-by-sa-3.0"
+        ], 
+        "name": "de-he", 
+        "categories": [
+            "Images from Wiki Loves Monuments 2011, DE-HE"
+        ], 
+        "desc": "Germany (Hesse)"
+    }, 
+    {
+        "licenses": [
+            "cc-by-sa-3.0"
+        ], 
+        "name": "de-nrw-bm", 
+        "categories": [
+            "Cultural heritage monuments in Bergheim"
+        ], 
+        "desc": "Germany (nrw-bm)"
+    }, 
+    {
+        "licenses": [
+            "cc-by-sa-3.0"
+        ], 
+        "name": "de-nrw-k", 
+        "categories": [
+            "Maintenance for cultural heritage monuments in Cologne"
+        ], 
+        "desc": "Germany (nrw-k)"
+    }, 
+    {
+        "licenses": [
+            "cc-by-sa-3.0-lu"
+        ], 
+        "name": "lu", 
+        "categories": [
+            "Cultural heritage monuments in Luxembourg"
+        ], 
+        "desc": "Luxemburg"
+    }, 
+    {
+        "licenses": [
+            "cc-by-sa-3.0-nl"
+        ], 
+        "name": "nl", 
+        "categories": [
+            "Rijksmonumenten"
+        ], 
+        "desc": "Netherlands"
+    }, 
+    {
+        "licenses": [
+            "cc-by-sa-3.0-no"
+        ], 
+        "name": "no", 
+        "categories": [
+            "Cultural heritage monuments in Norway"
+        ], 
+        "desc": "Norway"
+    }, 
+    {
+        "licenses": [
+            "cc-by-sa-3.0-pl"
+        ], 
+        "name": "pl", 
+        "categories": [], 
+        "desc": "Poland"
+    }, 
+    {
+        "licenses": [
+            "cc-by-sa-3.0"
+        ], 
+        "name": "pt", 
+        "categories": [
+            "Cultural heritage monuments in Portugal"
+        ], 
+        "desc": "Portugal"
+    }, 
+    {
+        "licenses": [
+            "cc-by-sa-3.0-ro"
+        ], 
+        "name": "ro", 
+        "categories": [
+            "Historical_monuments_in_Romania"
+        ], 
+        "desc": "Romania"
+    }, 
+    {
+        "licenses": [
+            "cc-by-sa-3.0", 
+            "cc-by-3.0", 
+            "own-pd", 
+            "cc-by-sa-3.0-es"
+        ], 
+        "name": "es", 
+        "categories": [
+            "Category:Cultural heritage monuments in Spain"
+        ], 
+        "desc": "Spain"
+    }, 
+    {
+        "licenses": [
+            "cc-by-sa-3.0"
+        ], 
+        "name": "se", 
+        "categories": [
+            "Protected buildings in Sweden"
+        ], 
+        "desc": "Sweden"
+    }, 
+    {
+        "licenses": [
+            "cc-by-sa-3.0"
+        ], 
+        "name": "ch", 
+        "categories": [
+            "Cultural properties of national significance in Switzerland"
+        ], 
+        "desc": "Switzerland"
+    }
+]

--- a/scripts/generate_campaigns.py
+++ b/scripts/generate_campaigns.py
@@ -1,0 +1,33 @@
+from urllib2 import urlopen, HTTPError
+try:
+    import json
+except:
+    import simplejson as json
+
+UPLOADCAMPAIGN_URL = "http://commons.wikimedia.org/w/api.php?action=uploadcampaign&format=json&ucprop=config"
+NAMES_URL = "http://commons.wikimedia.org/wiki/Commons:Monuments_database/Campaign_names?action=raw"
+
+campdata = json.loads(urlopen(UPLOADCAMPAIGN_URL).read())['uploadcampaign']['campaigns']
+
+# HACK: Bring up display names from separate file on wiki for now. Should be added to UploadCampaign info itself, or surfaced via Admin listings soon
+nametext = urlopen(NAMES_URL).read()
+namesdata = dict([(s.split('=')[0].strip(), s.split('=')[1].strip()) for s in nametext.split("\n")])
+
+campaigns = []
+
+for camp in campdata:
+	if camp['name'].startswith('wlm'):
+		campaign = {
+				'name': camp['name'].replace('wlm-', ''),
+				'categories': camp['config']['defaultCategories'],
+				'licenses': camp['config']['licensesOwnWork']
+				}
+		if campaign['name'] in namesdata:
+			campaign['desc'] = namesdata[campaign['name']]
+			# Only pickup campaings that have a description set
+			campaigns.append(campaign)
+			print campaign['name'], campaign['desc']
+
+campaigns = sorted(campaigns,  key=lambda k: k['desc'])
+
+open("campaigns-data.js", "w").write('window.CAMPAIGNS = ' + json.dumps(campaigns, indent=4))


### PR DESCRIPTION
Currently the campaigns _must_ have an entry in both UploadWizard
and in
http://commons.wikimedia.org/wiki/Commons:Monuments_database/Campaign_names
for them to show up. The latter part should be eliminated soon, with
UploadWizard entry being the only criterion
