### PR TITLE
about page, localization and select option localization

### DIFF
--- a/assets/www/app.css
+++ b/assets/www/app.css
@@ -37,6 +37,10 @@ input {
 	-webkit-user-modify: read-write-plaintext-only;
 }
 
+select {
+	font-size: 100%;
+}
+
 /* General utility styles */
 
 .center {
@@ -106,6 +110,9 @@ header.actionbar.hidden {
 }
 
 .page header h2 select {
+	position: relative;
+	top: -3px;
+	left: 0;
 	border-bottom: 2px #D1D1D1 solid;
 	border-right: 2px #d1d1d1 solid;
 }
@@ -158,6 +165,7 @@ button {
 	width: 100%;
 	font-size: 18px;
 	border: 0px;
+	cursor: pointer;
 }
 
 input[type='text'] {
@@ -229,6 +237,16 @@ header .back {
 	width: 24px;
 	height: 48px;
 	margin-left: 5px;
+}
+
+#about {
+	background: url('images/2-action-about.png') no-repeat;
+	background-position: top center;
+	width: 78px;
+	height: 78px;
+	padding-top:50px;
+	color: #000;
+	text-indent: -9999px;
 }
 
 /* Welcome page Styles */

--- a/assets/www/index.html
+++ b/assets/www/index.html
@@ -79,11 +79,12 @@
 			<button id="continue-upload"><msg key="confirm-license-upload" /></button>
 		</div>
 	</script>
-
+	
 	<div class="page" id="welcome-page">
 		<header class='actionbar'>
 			<img src="images/wlm-logo-cropped.png" />
 			<h2><msg key="welcome-title"></msg></h2>
+			<button id="about" title-msg="welcome-about"><msg key="welcome-about"></msg></button>
 		</header>
 		<div class="content">
 			<div class='center'><img src="images/intro-location-icon.png" height="128" /></div>
@@ -94,6 +95,19 @@
 				<br />
 				<button id="nearby"><msg key="welcome-nearby"></msg></button>
 			</div>
+		</div>
+	</div>
+	
+	<div class="page" id="about-page">
+		<header class='actionbar'>
+			<a class='back' data-page="welcome-page" href="#" title-msg="back"> </a>
+			<h2 data-localize-msg="about"></h2>
+		</header>
+		<div class="content">
+			<h3 data-localize-msg="welcome-title"></h3>
+			<p data-localize-msg="about-wlm-p1"></p>
+			<h3 data-localize-msg="about-rules-heading"></h3>
+			<p data-localize-msg="about-rules-p1"></p>
 		</div>
 	</div>
 
@@ -124,9 +138,8 @@
 			<a class='back' href="#"> </a>
 			<h2>
 				<select id="toggle-result-view">
-					<!-- FIXME: Find why jquery.localize doesn't seem to hit <option> tags -->
-					<option value="list-view">List View</option>
-					<option value="map-view">Map View</option>
+					<option value="list-view" data-option-msg="dropdown-list-view"></option>
+					<option value="map-view" data-option-msg="dropdown-map-view"></option>
 				</select>
 			</h2>
 			<a class="show-search"><img src='images/2-action-search.png' /></a>
@@ -282,7 +295,7 @@
 		</div>
 	</div>
 
-	<div class="page"  id="upload-latest-page">
+	<div class="page" id="upload-latest-page">
 		<header class="actionbar">
 			<a class='back' href="#"></a>
 			<h2>
@@ -297,7 +310,7 @@
 				<msg key="upload-latest-view"></msg>
 			</p>
 			<p>
-				<img src='loader.gif'>
+				<img id="upload-latest-status-spinner" src="images/loader.gif" />
 			</p>
 		</div>
 	</div>

--- a/assets/www/js/app.js
+++ b/assets/www/js/app.js
@@ -446,7 +446,11 @@ require( [ 'jquery', 'l10n', 'geo', 'api', 'templates', 'monuments', 'preference
 		$('#countries').click(function() {
 			showPage('country-page');
 		});
-
+		
+		$('#about').click(function() {
+			showPage('about-page');
+		});
+		
 		$( '.show-search' ).click( function() {
 			var page = $( this ).parents( '.page' ).attr( 'id' );
 			showSearchBar( page );

--- a/assets/www/js/jquery.localize.js
+++ b/assets/www/js/jquery.localize.js
@@ -17,6 +17,15 @@
  *			My Message
  *			<img src="something.jpg" title="My Title Message" alt="My Alt Message" />
  *		</p>
+ *
+ *	Available elements and attributes
+ *	<html:msg key="message-key" />
+ *	<msg key="message-key" />
+ *	title-msg="message-key"
+ *	alt-msg="message-key"
+ *	placeholder-msg="message-key"
+ *	data-localize-msg="message-key"
+ *	data-option-msg="message-key"
  */
 ( function( $ ) {
 /**
@@ -72,6 +81,20 @@ $.fn.localize = function( options ) {
 				$el
 					.attr( 'placeholder', msg( $el.attr( 'placeholder-msg' ) ) )
 					.removeAttr( 'placeholder-msg' );
+			} )
+			.end()
+		.find( '[data-localize-msg]' )
+			.each( function() {
+				var $el = $(this);
+				$el
+					.html( msg( $el.attr( 'data-localize-msg' ) ) );
+			} )
+			.end()
+		.find( 'option[data-option-msg]' )
+			.each( function() {
+				var $el = $(this);
+				$el
+					.html( msg( $el.attr( 'data-option-msg' ) ) );
 			} )
 			.end();
 };

--- a/assets/www/messages/messages-en.properties
+++ b/assets/www/messages/messages-en.properties
@@ -101,3 +101,8 @@ settings-account-header=Account
 settings-login=Login
 settings-logout=Logout
 settings-user-name=You are <strong>$1</strong>!
+
+about=About
+about-wlm-p1=This <b>contest</b> is ... Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+about-rules-heading=Contest Rules
+about-rules-p1=Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?


### PR DESCRIPTION
for your consideration ....
## list of changes
- fixed upload latest page's reference to the loader.gif -> it was missing images/
- added about icon with click event to the welcome page https://bugzilla.wikimedia.org/show_bug.cgi?id=38075
- added about page with mock-up content https://bugzilla.wikimedia.org/show_bug.cgi?id=38075
- added about page mock-content to the messages-en.properties file
- added data-localize-msg to jquery.localize -> allows for valid html markup, provides a method to circumvent ie issues mentioned with <msg key=""/> and <html:msg key=""/>
- added data-option-msg to jquery.localize -> provides a resolution to the issue where jquery.localize cannot .find the msg within the <option> elements
- added to the jquery.localize embedded documentation
- set the select font-size to 100% and re-positioned the select to better align with the back icon -> shows up on the results-page header
