### PR TITLE
separate map page from monuments page (bug 38342)

### DIFF
--- a/assets/www/index.html
+++ b/assets/www/index.html
@@ -123,10 +123,10 @@
 		<header class='actionbar'>
 			<a class='back' href="#"> </a>
 			<h2>
-				<select id="toggle-result-view">
+				<select class="toggle-page">
 					<!-- FIXME: Find why jquery.localize doesn't seem to hit <option> tags -->
-					<option value="list-view">List View</option>
-					<option value="map-view">Map View</option>
+					<option value="results-page" selected>List View</option>
+					<option value="map-page">Map View</option>
 				</select>
 			</h2>
 			<a class="show-search"><img src='images/2-action-search.png' /></a>
@@ -148,8 +148,23 @@
 			<ul class="monuments-sorter" id="monuments-sort"></ul>
 			<ul class="monuments-list" id="results"></ul>
 		</div>
-		<div class="content hidden" id="map">
-		</div>
+	</div>
+
+	<div class="page" id="map-page">
+		<header class='actionbar'>
+			<a class='back' href="#"> </a>
+			<h2>
+				<select class="toggle-page">
+					<!-- FIXME: Find why jquery.localize doesn't seem to hit <option> tags -->
+					<option value="map-page" selected>Map View</option>
+					<option value="results-page">List View</option>
+				</select>
+			</h2>
+			<a class="show-search"><img src='images/2-action-search.png' /></a>
+			<a class='page-link' data-page='country-page'><img src='images/7-location-place.png' /></a>
+			<a class='page-link' data-page='settings-page'><img src='images/2-action-settings.png' /></a>
+		</header>
+		<div class="content" id="map"></div>
 	</div>
 
 	<div class="page has-tabbar" id="uploads-page">

--- a/assets/www/test/fixtures.js
+++ b/assets/www/test/fixtures.js
@@ -10,8 +10,11 @@ var L = {
 // SETUP TEMPLATES
 var DUMMY_TEMPLATES = {
 	'country-list-template': '<div></div>',
+	'map-page-stub': '<div></div>',
 	'monument-list-item-template': '<li>foo</li>',
-	'monument-list-empty-template': '<div>empty</div>'
+	'monument-list-empty-template': '<div>empty</div>',
+	'results-page': [ '<select class="toggle-page"><option value="results-page">list</option>',
+	 	'<option value="map-page-stub">map</option></select>' ].join( '' )
 };
 for( var id in DUMMY_TEMPLATES ) {
 	if( DUMMY_TEMPLATES.hasOwnProperty( id ) ) {

--- a/assets/www/test/js/app.js
+++ b/assets/www/test/js/app.js
@@ -28,4 +28,13 @@ test( 'empty monuments list', function() {
 	app.showMonumentsList( [] );
 	strictEqual( $( '#results' ).text(), 'empty' );
 } )
+
+test( 'toggling view type', function() {
+	var app = WLMMobile.app;
+	app.showPage( 'results-page' );
+	$( '#results-page .toggle-page' ).val( 'map-page-stub' );
+	app.showPage( 'results-page' );
+	strictEqual( $( '#results-page .toggle-page' ).val(), 'results-page', 'check map view remains selected' );
+} );
+
 }());


### PR DESCRIPTION
- this separates the map into its own specific page
- this allows us to re-use the page handling
- made the toggle view dropdown more generic and allow switching between pages
- only reset the map view when the user navigates to country page or clicks use
  my location to allow switching between views
- add tests
