### PR TITLE
support attribute localization

### DIFF
--- a/assets/www/index.html
+++ b/assets/www/index.html
@@ -179,8 +179,8 @@
 			<h2>
 				<select class="toggle-page">
 					<!-- FIXME: Find why jquery.localize doesn't seem to hit <option> tags -->
-					<option value="map-page" selected>Map View</option>
-					<option value="results-page">List View</option>
+					<option value="map-page" selected data-option-msg="dropdown-list-view"></option>
+					<option value="results-page" data-option-msg="dropdown-map-view"></option>
 				</select>
 			</h2>
 			<a class="show-search"><img src='images/2-action-search.png' /></a>

--- a/assets/www/js/jquery.localize.js
+++ b/assets/www/js/jquery.localize.js
@@ -17,6 +17,15 @@
  *			My Message
  *			<img src="something.jpg" title="My Title Message" alt="My Alt Message" />
  *		</p>
+ *
+ *	Available elements and attributes
+ *	<html:msg key="message-key" />
+ *	<msg key="message-key" />
+ *	title-msg="message-key"
+ *	alt-msg="message-key"
+ *	placeholder-msg="message-key"
+ *	data-localize-msg="message-key"
+ *	data-option-msg="message-key"
  */
 ( function( $ ) {
 /**
@@ -72,6 +81,20 @@ $.fn.localize = function( options ) {
 				$el
 					.attr( 'placeholder', msg( $el.attr( 'placeholder-msg' ) ) )
 					.removeAttr( 'placeholder-msg' );
+			} )
+			.end()
+		.find( '[data-localize-msg]' )
+			.each( function() {
+				var $el = $(this);
+				$el
+					.html( msg( $el.attr( 'data-localize-msg' ) ) );
+			} )
+			.end()
+		.find( 'option[data-option-msg]' )
+			.each( function() {
+				var $el = $(this);
+				$el
+					.html( msg( $el.attr( 'data-option-msg' ) ) );
 			} )
 			.end();
 };


### PR DESCRIPTION
added data-localize-msg to jquery.localize -> allows for valid html markup,
provides a method to circumvent ie issues mentioned with <msg key=""/> and <html:msg key=""/>
added data-option-msg to jquery.localize -> provides a resolution to the issue
where jquery.localize cannot .find the msg within the <option> elements
added to the jquery.localize embedded documentation
