### PR TITLE
update map with monuments as user explores (bug 38346)

### DIFF
--- a/assets/www/js/app.js
+++ b/assets/www/js/app.js
@@ -197,11 +197,38 @@ require( [ 'jquery', 'l10n', 'geo', 'api', 'templates', 'monument',
 		$("#monuments-list").show();
 	}
 
-	function showMonumentsMap(monuments, center, zoom) {
-		geo.init();
+	function showMonumentsMap( monumentList, center, zoom ) {
+		var searchTimeout, lastRequest;
+		function addMonuments( monuments ) {
+			$.each( monuments, function( i, monument ) {
+				if ( monument.lat && monument.lon ) {
+					geo.addMonument( monument, showMonumentDetail );
+				}
+			} );
+		}
+		function ping( ev ) {
+			console.log( 'update map with new monuments' );
+			var pos = ev.target.getBounds(),
+				nw = pos.getNorthWest(),
+				se = pos.getSouthEast();
+			if( lastRequest ) {
+				lastRequest.abort();
+			}
+			window.clearTimeout( searchTimeout );
+			searchTimeout = window.setTimeout( function() {
+				lastRequest = monuments.getInBoundingBox( nw.lng, se.lat, se.lng, nw.lat ).done( function( monuments ) {
+					if ( monuments.length > 0 ) {
+						geo.clear();
+						addMonuments( monuments );
+						$( '#results' ).data( 'monuments', monuments );
+					}
+				}, 500 ); // delaying search to prevent stressing out server
+			} );
+		}
+		geo.init( ping );
 		geo.clear();
 		if( mapFocusNeeded && typeof center === 'undefined' && typeof zoom === 'undefined' ) {
-			var centerAndZoom = geo.calculateCenterAndZoom(monuments);
+			var centerAndZoom = geo.calculateCenterAndZoom( monumentList );
 			center = centerAndZoom.center;
 			zoom = centerAndZoom.zoom;
 			mapFocusNeeded = false;
@@ -209,11 +236,7 @@ require( [ 'jquery', 'l10n', 'geo', 'api', 'templates', 'monument',
 		if( center && zoom ) {
 			geo.setCenterAndZoom( center, zoom );
 		}
-		$.each(monuments, function(i, monument) {
-			if(monument.lat && monument.lon) {
-				geo.addMonument(monument, showMonumentDetail);
-			}
-		});
+		addMonuments( monumentList );
 	}
 
 	function displayError( heading, text ) {

--- a/assets/www/js/geo.js
+++ b/assets/www/js/geo.js
@@ -53,7 +53,7 @@ define(['jquery', '../leaflet/leaflet-src', 'leafclusterer'], function() {
 		return location;
 	}
 
-	function init() {
+	function init( onmapchange ) {
 		if (!map) {
 			// Disable webkit 3d CSS transformations for tile positioning
 			// Causes lots of flicker in PhoneGap for some reason...
@@ -87,6 +87,10 @@ define(['jquery', '../leaflet/leaflet-src', 'leafclusterer'], function() {
 			// Since clusterer needs to have a default view setup
 			map.setView( new L.LatLng( 0, 0 ), 3 );
 			clusterer = new LeafClusterer(map);
+
+			if ( onmapchange ) { 
+				map.on( 'moveend', onmapchange );
+			}
 		}
 	}
 


### PR DESCRIPTION
as the user moves around the map update the view to show monuments in
the vicinity
- rename monuments variable so it doesn't interfere with monument in
  higher scope
- allow addition of a onmapchange event
