### PR TITLE
specify position of pages to remove 1px gap at the top of the page

### DIFF
--- a/assets/www/app.css
+++ b/assets/www/app.css
@@ -58,6 +58,13 @@ header.actionbar.hidden {
 
 /* Generic page layout styles */
 
+.page {
+	position: absolute;
+	right: 0;
+	left: 0;
+	top: 0;
+	bottom: 0;
+}
 .page header.actionbar {
 	position: fixed;
 	height: 48px;


### PR DESCRIPTION
seems like default browser css introduces a 1px gap without this
