### PR TITLE
don't assume top = 0 (bug 38332)

### DIFF
--- a/assets/www/app.css
+++ b/assets/www/app.css
@@ -74,6 +74,7 @@ header.actionbar.hidden {
 	-webkit-box-align: center;
 	z-index: 200;
 	padding: 4px 5px;
+	top: 0;
 }
 
 .page header.actionbar img {


### PR DESCRIPTION
this seems to resolve the issue with the header jumping by 2px when
clicking on the select menu
