### PR TITLE
Fix for crash on landscape mode under Cordova 2.0

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -22,7 +22,7 @@
     <application android:icon="@drawable/ic_launcher" android:label="@string/app_name"
         android:debuggable="true">
         <activity android:name="org.wikipedia.wlm.WikiLovesMonuments" android:label="@string/app_name" 
-                  android:configChanges="orientation|keyboardHidden">
+                  android:configChanges="orientation|screenSize|keyboardHidden">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/README
+++ b/README
@@ -4,12 +4,11 @@ To import Android project to Eclipse:
 * create new project
 ** new "Android project"
 ** "from existing sources"
-** set API level to 2.3.3
+** set target API level to 4.0
 * go to project properties, make sure compiler is set to Java 1.6
 
 
 PhoneGap/Cordova issues:
 
 * https://issues.apache.org/jira/browse/CB-622 - no way to get progress information from FileTransfer
-
 

--- a/project.properties
+++ b/project.properties
@@ -11,4 +11,4 @@
 #proguard.config=${sdk.dir}/tools/proguard/proguard-android.txt:proguard-project.txt
 
 # Project target.
-target=android-10
+target=android-14


### PR DESCRIPTION
See thread https://groups.google.com/forum/?fromgroups#!msg/phonegap/HYUfLJF1oH0/r9rZTfz_cccJ

Adds 'screenSize' into application entry's changes section, ups build target to 4.0. Should still run on 2.3 as long as we don't use any new stuff.
