### PR TITLE
Use an <a> for about icon instead of <button>

### DIFF
--- a/assets/www/app.css
+++ b/assets/www/app.css
@@ -207,16 +207,6 @@ button.myLocation.loading {
 	background-position: center;
 }
 
-header button#about {
-	background: none;
-	background-image: url(images/2-action-about.png);
-	text-indent: -999px;
-	background-repeat: no-repeat;
-	margin: 0; /* remove default margins */
-	width: 40px;
-	background-position: center center;
-}
-
 input[type='text'] {
 	-webkit-appearance: none;
 	appearance: none;

--- a/assets/www/index.html
+++ b/assets/www/index.html
@@ -133,9 +133,9 @@
 		<header class='actionbar'>
 			<img src="images/wlm-logo-cropped.png" />
 			<h2><msg key="welcome-title"></msg></h2>
-			<button id="about" class='page-link' data-page='about-page'>
-				<msg key="welcome-about"></msg>
-			</button>
+			<a class='page-link' data-page='about-page'>
+				<img src='images/2-action-about.png' />
+			</a>
 		</header>
 		<div class="content">
 			<div class='center'><img src="images/intro-location-icon.png" height="128" /></div>


### PR DESCRIPTION
Consistent with all other action bar icons. Plus it is just a
link to the about page, so using <a> makes semantic sense

Replaces #83
