### PR TITLE
cleanup qqq codes (bug 38892)

### DIFF
--- a/assets/www/messages/messages-en.properties
+++ b/assets/www/messages/messages-en.properties
@@ -20,7 +20,6 @@ dropdown-map-view=Map view
 dropdown-list-view=List view
 start-upload=Upload
 cancel-upload=Cancel upload
-filter-label=Filter:
 
 attribution-mapquest = Tiles courtesy <a href="http://www.mapquest.com">MapQuest</a>
 attribution-osm = Map Data (C) <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>
@@ -45,7 +44,6 @@ detail-source=Source
 login-title=Log in to continue
 login=Login
 login-in-progress = Logging you into the magical world of Wikimedia Commons...
-login-success = Logged in!
 login-failed = Login failed
 login-failed-username = There was something wrong with the username you entered.
 login-failed-password = There was something wrong with the password you provided.
@@ -64,10 +62,7 @@ change-photo=Change
 continue-upload=Continue
 skip-warning=Don't show this again
 
-uploading-status=Images are being uploaded...
-
 no-monuments=No monuments to love in this country.
-tabbar-monuments=Monuments
 tabbar-uploads=Uploads
 
 monument-sortby-heading=sort by

--- a/assets/www/messages/messages-qqq.properties
+++ b/assets/www/messages/messages-qqq.properties
@@ -1,23 +1,36 @@
 welcome-title=Application welcome screen title
+welcome-about=Link text to about page on the welcome screen
 welcome-intro=Brief description of the app on welcome screen.
 welcome-start=Prompt on the welcome screen. Campaigns are per-region or per-country.
-welcome-search=Campaign pseudo-entry title to just search near current coordinates instead of picking a region.
-welcome-rules=Link text for link to contest rules
+welcome-browse=Label for button to browse various global campaigns
+welcome-nearby=Label for button to use current location to find monuments
+
+choose-campaign=heading for page where you choose a campaign
 
 back='Back' button label used in several page headers.
+popup-cancel=button on popups that allows you to cancel (exit) it
+popup-ok=ok button for confirming when you are finished reading a popup
 
-about=heading for the about page
-about-wlm-p1=an html/text string that describes the game
+geolocating-heading=Heading for splash screen whilst user location is being looked up
+geolocating-text=Message displayed whilst your location is looked up via geolocation services (usually wifi/gps)
+geolocating-failed-heading=Heading of page reporting failure to locate you
+geolocating-failed-text=More information on how a user's location may be discovered (join a wifi network / get a clear sky for gps)
 
-show-map=Button label to switch from list to map view on search results.
-show-list=Button label to switch from map to list view on search results.
-filter-label=Filter:
+dropdown-map-view=On the monuments list page label for dropdown allowing user to swap to a map view
+dropdown-list-view=On the monuments map page label for dropdown allowing user to swap to a list of search results
+start-upload=Button label on detail page to start an upload process for this monument.
+cancel-upload=label for button to cancel uploading of photo whilst it is in progress
 
-attribution-mapquest = Tiles courtesy <a href="http://www.mapquest.com">MapQuest</a>
-attribution-osm = Map Data (C) <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>
+attribution-mapquest=Attribution for map titles
+attribution-osm=Attribution for OSM data
+
+failure-heading=Generic error message heading for when we are not sure what went wrong
+failure-details=Generic error message for when we are not sure what went wrong
+
+server-issue-heading=Error message heading to show when API fails
+server-issue-text=Error message to show when API fails
 
 detail-title=Page title for monument detail page.
-start-upload=Button label on detail page to start an upload process for this monument.
 detail-link=Link text for link to the monument's article on the monument detail page.
 detail-address=Field label for monument detail page.
 detail-municipality=Field label for monument detail page.
@@ -28,21 +41,67 @@ detail-id=Field label for monument detail page.
 detail-changed=Field label for monument detail page.
 detail-source=Link text for link to the data source URL on the monument detail page.
 
-server-issue-heading=Error message heading to show when API fails
-server-issue-text=Error message to show when API fails
-
 login-title=Fieldset title for login form
 login=Button label for login form
+login-in-progress=Message to inform user an attempt to log them in is occurring
+login-failed=Error message heading for when login fails
+login-failed-username=Message to report a login failed due to a bad username
+login-failed-password=Message to report a login failed due to a bad password
+login-failed-blocked=Message to report a login failed due to the user being blocked
+login-failed-throttled=Message to report a login failed due to the user being throttled
+login-failed-internal=Message to report a login failed due to token issue
+login-failed-default=Generic error message to report a login failed without reason
 login-create-account=Message and link for a user to create an account on commons.wikimedia.org
 
-selectphoto=Button label for selecting an existing photo from the device's saved galleries.
-takephoto=Button label for taking a new photo.
+add-photo-title=Heading for page which gives options for how to upload an image for a given monument
+add-photo-gallery=Label for button that user clicks to upload a photo from their gallery
+add-photo-camera=Label for button that user clicks to upload a photo via their camera
 
 size-warning=Warning label indicating size of the image that's about to be uploaded so the user can confirm whether they want to do it now. $1 is size in kilobytes.
-change-photo=Button label to abort upload, go back and get a new photo. 
+change-photo=Button label to abort upload, go back and get a new photo.
 continue-upload=Button label to continue with the upload.
-skip-warning=Checkbox label offering to skip the file size warning in future. 
+skip-warning=Checkbox label offering to skip the file size warning in future.
 
-uploading-status=Status message during uploading.
+no-monuments=Appears in lists where no monuments are found
+tabbar-uploads=Heading for uploads page which lists all the images a user has uploaded
+
+monument-sortby-heading=On monuments results page prefixes a list of buttons that allow you to sort and in future filter results
+monument-sortby-address=Button label for sorting monuments by address
+monument-sortby-name=Button label for sorting monuments by name
+monument-sortby-distance=Button label for sorting by distance from users current location
+
+monument-distance-km=Distance in km to 1 decimal place of user to monument
+monument-directions=Link label for accessing directions
+monument-address=Text that prefixes the address
+monument-country=On monument page under title of monument this is text that prefixes which campaign the monument is part of
+monument-no-address=When the address of a monument is not known this is shown instead.
+
+confirm-license-title=Heading for confirming the license on upload page
+confirm-license-text=Text about the license
+confirm-license-upload=Button for confirming license/photo and starting an upload
+
+confirm-upload-title=Heading for confirm page
+
+upload-progress-title=Title of popup whilst an upload is in progress
+upload-progress-starting=Initial message whilst a photo is being prepared
+upload-progress-in-progress=Message to display whilst posting the photo
+upload-progress-done=Message to display when an upload was successful
+upload-progress-failed=Message to display when an upload failed
+
+search-country-placeholder=placeholder message for search by campaign name
+search-monument-placeholder=placeholder message for search by monument name
+
+upload-latest-title=Title of an upload selected from the uploads page
+upload-latest-view=Prompt to get user to share their photo. Contains an anchor tag which is going to link to a url for the image file page.
+no-uploads=Message to show user when they go to uploads page having uploaded nothing
 upload-completeddetail-title=When viewing a photo the user uploaded this is the heading
 upload-monument-link-text=Label for link that takes user from photo upload page to monument
+
+settings-title=Title of settings page
+settings-account-header=heading for section regarding account information and login status on the settings page
+settings-login=Label for login button pointing to login page.
+settings-logout=label for log out button
+settings-user-name=Information about the current user (can be html)
+
+about=heading for the about page
+about-wlm-p1=an html/text string that describes the game


### PR DESCRIPTION
move qqq definitions around so that they match up order of english
remove unused messages
describing messages where no description present
remove trailing whitespace and whitespace around = symbol
save the princess
