### PR TITLE
Less hacky fix for bug 38933

### DIFF
--- a/assets/www/js/app.js
+++ b/assets/www/js/app.js
@@ -262,6 +262,7 @@ require( [ 'jquery', 'l10n', 'geo', 'api', 'templates', 'monuments', 'monument',
 
 	function showMonumentsMap( monumentList, center, zoom ) {
 		geo.clear();
+		geo.onResize(); // hack to ensure resize on re-show after orientation change
 		if( mapFocusNeeded && typeof center === 'undefined' && typeof zoom === 'undefined' ) {
 			var centerAndZoom = geo.calculateCenterAndZoom( monumentList );
 			center = centerAndZoom.center;
@@ -272,12 +273,6 @@ require( [ 'jquery', 'l10n', 'geo', 'api', 'templates', 'monuments', 'monument',
 			geo.setCenterAndZoom( center, zoom );
 		}
 		addMonuments( monumentList );
-		window.setTimeout(function() {
-			// This feels like a HORRIBLE hack.
-			// If we invalidate immediately, we end up squishing the virtual map
-			// area into 0x0 or something. With this delay, it fixes up ok...
-			geo.getMap().invalidateSize();
-		}, 500);
 	}
 
 	function displayError( heading, text ) {

--- a/assets/www/js/app.js
+++ b/assets/www/js/app.js
@@ -272,6 +272,12 @@ require( [ 'jquery', 'l10n', 'geo', 'api', 'templates', 'monuments', 'monument',
 			geo.setCenterAndZoom( center, zoom );
 		}
 		addMonuments( monumentList );
+		window.setTimeout(function() {
+			// This feels like a HORRIBLE hack.
+			// If we invalidate immediately, we end up squishing the virtual map
+			// area into 0x0 or something. With this delay, it fixes up ok...
+			geo.getMap().invalidateSize();
+		}, 500);
 	}
 
 	function displayError( heading, text ) {

--- a/assets/www/js/geo.js
+++ b/assets/www/js/geo.js
@@ -53,6 +53,19 @@ define(['jquery', '../leaflet/leaflet-src', 'leafclusterer'], function() {
 		return location;
 	}
 
+	function onResize() {
+		// HACK: we're calling an internal function here for convenience.
+		//
+		// What we really care about is calling map.invalidateSize() after
+		// a short delay to ensure that DOM state has updated for any showing/
+		// hiding going on.
+		//
+		// The internal function uses a handy utility function to use the
+		// requestAnimationFrame interface instead of a crude setTimeout.
+		//
+		map._onResize();
+	}
+
 	function init( onmapchange ) {
 		if (!map) {
 			// Disable webkit 3d CSS transformations for tile positioning
@@ -60,7 +73,14 @@ define(['jquery', '../leaflet/leaflet-src', 'leafclusterer'], function() {
 			L.Browser.webkit3d = false;
 			map = new L.Map('map', {
 				touchZoom: false,
-				zoomControl: true
+				zoomControl: true,
+				trackResize: false
+			});
+			$(window).resize(function() {
+				// Don't resize when invisible; it's unnecessary and can break.
+				if ($('#map-page').is(':visible')) {
+					onResize();
+				}
 			});
 			var tiles = new L.TileLayer('http://otile{s}.mqcdn.com/tiles/1.0.0/osm/{z}/{x}/{y}.png', {
 				maxZoom: 18,
@@ -134,7 +154,8 @@ define(['jquery', '../leaflet/leaflet-src', 'leafclusterer'], function() {
 		addMonument: addMonument,
 		calculateCenterAndZoom: calculateCenterAndZoom,
 		setCenterAndZoom: setCenterAndZoom,
-		getMap: getMap
+		getMap: getMap,
+		onResize: onResize
 	};
 
 });


### PR DESCRIPTION
Less hacky fix for bug 38933 - pass through to Leaflet's _onResize() handler

This is slightly cleaner:
- call map._onResize() which wraps an invalidateSize() in a requestAnimationFrame call, which is faster and less crude than a setTimeout
- manually call the _onResize handler during resize so we can avoid it when the map page is hidden -- that just breaks!
- abstract things a bit
