### PR TITLE
Bug 38283 / card 115: show proper CC license symbolic name in dialog

### DIFF
--- a/assets/www/js/app.js
+++ b/assets/www/js/app.js
@@ -294,9 +294,10 @@ require( [ 'jquery', 'l10n', 'geo', 'api', 'templates', 'monuments', 'monument',
 		console.log("Filename is " + fileName);
 		var text = formatUploadDescription( curMonument, CAMPAIGNS[ curMonument.country ].config, api.userName );
 		console.log( "Page text is " + text );
+		var licenseText = formatLicenseText( CAMPAIGNS[ curMonument.country ].config );
 
 		$("#upload-confirm").html(uploadConfirmTemplate({monument: curMonument, fileUrl: fileUrl})).localize();
-		$("#confirm-license-text").html(mw.msg('confirm-license-text', api.userName));
+		$("#confirm-license-text").html(mw.msg('confirm-license-text', api.userName, licenseText));
 		$("#continue-upload").click(function() {
 			// reset status message for any previous uploads
 			$( '#upload-progress-state' ).html(mw.msg( 'upload-progress-starting' ));
@@ -500,6 +501,10 @@ require( [ 'jquery', 'l10n', 'geo', 'api', 'templates', 'monuments', 'monument',
 			};
 		var template = templates.getTemplate( 'upload-photo-description', true )( { descData: descData } );
 		return template;
+	}
+	
+	function formatLicenseText( campaignConfig ) {
+		return campaignConfig.defaultOwnWorkLicence; // note the typo in the API field
 	}
 
 	// Expects user to be logged in

--- a/assets/www/messages/messages-en.properties
+++ b/assets/www/messages/messages-en.properties
@@ -77,7 +77,7 @@ monument-country=Campaign:
 monument-no-address=No address found!
 
 confirm-license-title=License
-confirm-license-text=I took this photo <br />I, $1, the copyright holder of this work, irrevocably grant anyone the right to use this work under the following license: <br />CC-BY-SA 3.0 Unported License
+confirm-license-text=I took this photo <br />I, $1, the copyright holder of this work, irrevocably grant anyone the right to use this work under the following license: <br />$2
 confirm-license-upload=Upload
 
 confirm-upload-title=Confirm Upload


### PR DESCRIPTION
Takes the defaultOwnWorkLicence field and displays it straight.
