### PR TITLE
Card 130 / bug 38869: link to license code on upload confirmation page

### DIFF
--- a/assets/www/app.css
+++ b/assets/www/app.css
@@ -41,6 +41,12 @@ a {
 	color: inherit;
 }
 
+/* At last make external links easy to find? */
+a.external {
+	text-decoration: underline;
+	color: #00f;
+}
+
 input {
 	/* see: http://stackoverflow.com/questions/9005550/input-elements-on-android-4-x-can-not-be-styled-when-focused */
 	-webkit-user-modify: read-write-plaintext-only;

--- a/assets/www/js/app.js
+++ b/assets/www/js/app.js
@@ -20,7 +20,7 @@ function handleOpenURL(url)
 }
 */
 require( [ 'jquery', 'l10n', 'geo', 'api', 'templates', 'monuments', 'monument', 'preferences', 'database', 
-		'jquery.localize', 'campaigns-data' ],
+		'jquery.localize', 'campaigns-data', 'licenses-data' ],
 	function( $, l10n, geo, Api, templates, MonumentsApi, Monument, prefs, db ) {
 
 	var api = new Api("https://test.wikipedia.org/w/api.php");
@@ -519,7 +519,19 @@ require( [ 'jquery', 'l10n', 'geo', 'api', 'templates', 'monuments', 'monument',
 	}
 	
 	function formatLicenseText( campaignConfig ) {
-		return campaignConfig.defaultOwnWorkLicence; // note the typo in the API field
+		var key = campaignConfig.defaultOwnWorkLicence, // note the typo in the API field
+			text = key,
+			$stub = $( '<span>' );
+		if (key in LICENSES && 'url' in LICENSES[key] ) {
+			var $link = $( '<a>' )
+				.text( text )
+				.attr( 'class', 'external' )
+				.attr( 'href', LICENSES[key].url )
+				.appendTo( $stub );
+		} else {
+			$stub.text( text );
+		}
+		return $stub.html();
 	}
 
 	// Expects user to be logged in

--- a/assets/www/js/licenses-data.js
+++ b/assets/www/js/licenses-data.js
@@ -1,0 +1,90 @@
+// Copied from UploadWizard default configuration
+window.LICENSES = {
+		'cc-by-sa-3.0' : {
+			'icons' : [ 'cc-by', 'cc-sa' ],
+			'url' : 'https://creativecommons.org/licenses/by-sa/3.0/'
+		},
+		'cc-by-sa-3.0-gfdl' : {
+			'templates' : [ 'GFDL', 'cc-by-sa-3.0' ],
+			'icons' : [ 'cc-by', 'cc-sa' ]
+		},
+		'cc-by-sa-3.0-at' : {
+			'templates' : [ 'cc-by-sa-3.0-at' ],
+			'icons' : [ 'cc-by', 'cc-sa' ],
+			'url' : 'https://creativecommons.org/licenses/by-sa/3.0/at/'
+		},
+		'cc-by-sa-3.0-de' : {
+			'templates' : [ 'cc-by-sa-3.0-de' ],
+			'icons' : [ 'cc-by', 'cc-sa' ],
+			'url' : 'https://creativecommons.org/licenses/by-sa/3.0/de/'
+		},
+		'cc-by-sa-3.0-ee' : {
+			'templates' : [ 'cc-by-sa-3.0-ee' ],
+			'icons' : [ 'cc-by', 'cc-sa' ],
+			'url' : 'https://creativecommons.org/licenses/by-sa/3.0/ee/'
+		},
+		'cc-by-sa-3.0-es' : {
+			'templates' : [ 'cc-by-sa-3.0-es' ],
+			'icons' : [ 'cc-by', 'cc-sa' ],
+			'url' : 'https://creativecommons.org/licenses/by-sa/3.0/es/'
+		},
+		'cc-by-sa-3.0-hr' : {
+			'templates' : [ 'cc-by-sa-3.0-hr' ],
+			'icons' : [ 'cc-by', 'cc-sa' ],
+			'url' : 'https://creativecommons.org/licenses/by-sa/3.0/hr/'
+		},
+		'cc-by-sa-3.0-lu' : {
+			'templates' : [ 'cc-by-sa-3.0-lu' ],
+			'icons' : [ 'cc-by', 'cc-sa' ],
+			'url' : 'https://creativecommons.org/licenses/by-sa/3.0/lu/'
+		},
+		'cc-by-sa-3.0-nl' : {
+			'templates' : [ 'cc-by-sa-3.0-nl' ],
+			'icons' : [ 'cc-by', 'cc-sa' ],
+			'url' : 'https://creativecommons.org/licenses/by-sa/3.0/nl/'
+		},
+		'cc-by-sa-3.0-no' : {
+			'templates' : [ 'cc-by-sa-3.0-no' ],
+			'icons' : [ 'cc-by', 'cc-sa' ],
+			'url' : 'https://creativecommons.org/licenses/by-sa/3.0/no/'
+		},
+		'cc-by-sa-3.0-pl' : {
+			'templates' : [ 'cc-by-sa-3.0-pl' ],
+			'icons' : [ 'cc-by', 'cc-sa' ],
+			'url' : 'https://creativecommons.org/licenses/by-sa/3.0/pl/'
+		},
+		'cc-by-sa-3.0-ro' : {
+			'templates' : [ 'cc-by-sa-3.0-ro' ],
+			'icons' : [ 'cc-by', 'cc-sa' ],
+			'url' : 'https://creativecommons.org/licenses/by-sa/3.0/ro/'
+		},
+		'cc-by-3.0' : {
+			'icons' : [ 'cc-by' ],
+			'url' : 'https://creativecommons.org/licenses/by/3.0/'
+		},
+		'cc-zero' : {
+			'icons' : [ 'cc-zero' ],
+			'url' : 'https://creativecommons.org/publicdomain/zero/1.0/'
+		},
+		'own-pd' : {
+			'icons' : [ 'cc-zero' ],
+			'templates' : [ 'cc-zero' ]
+		},
+		'cc-by-sa-2.5' : {
+			'icons' : [ 'cc-by', 'cc-sa' ],
+			'url' : 'https://creativecommons.org/licenses/by-sa/2.5/'
+		},
+		'cc-by-2.5' : {
+			'icons' : [ 'cc-by' ],
+			'url' : 'https://creativecommons.org/licenses/by/2.5/'
+		},
+		'cc-by-sa-2.0' : {
+			'icons' : [ 'cc-by', 'cc-sa' ],
+			'url' : 'https://creativecommons.org/licenses/by-sa/2.0/'
+
+		},
+		'cc-by-2.0' : {
+			'icons' : [ 'cc-by' ],
+			'url' : 'https://creativecommons.org/licenses/by/2.0/'
+		}
+};


### PR DESCRIPTION
- makes external links blue/underlined to follow convention and make them visible
- copies some default configuration from UploadWizard to get the URLs for licenses
- where license URL is known from the symbolic key, link to it
