### PR TITLE
Bug 38744 / card 121: fix map attribution

### DIFF
--- a/assets/www/app.css
+++ b/assets/www/app.css
@@ -317,11 +317,18 @@ button.requires-location {
 	bottom: 0px;
 }
 
-.leaflet-control-container {
+.leaflet-control-zoom {
 	-webkit-transform: translate3d(0,0,0);
 	position: relative;
 	top: 0;
 	left: 0;
+	z-index: 7;
+}
+.leaflet-control-attribution {
+	-webkit-transform: translate3d(0,0,0);
+	position: relative;
+	bottom: 0;
+	right: 0;
 	z-index: 7;
 }
 


### PR DESCRIPTION
Commit aa32cd31 fix for controls being hidden on ICS was misplacing the attribution div. Tweaked to treat the controls and the attribution distinctly so they're both shown as expected.
