### PR TITLE
Allow drilling down from country level to campaign regions

### DIFF
--- a/assets/www/app.css
+++ b/assets/www/app.css
@@ -28,6 +28,10 @@ body {
 	min-height: 50px;
 }
 
+#campaign-page.loading h3 {
+	display: none;
+}
+
 .loading #results li {
 	display: none;
 }

--- a/assets/www/index.html
+++ b/assets/www/index.html
@@ -17,9 +17,10 @@
   </head>
   <body class='hidden'>
 	<script type="text/html" id="country-list-template">
-		<% _.each( _.sortBy( countries, function( country ) { return country.desc } ), function( country ) { %>
+		<% _.each( _.sortBy( campaigns, function( campaign ) { return campaign.desc } ), function( campaign ) { %>
 			<li>
-				<a class='country-search' data-campaign='<%= country.name %>' href="#"><%= country.desc %></a>
+				<a class='country-search' href='#'
+					data-campaign='<%= campaign.code %>'><%= campaign.name %></a>
 			</li>
 		<% }); %>
 	</script>
@@ -172,7 +173,7 @@
 		</div>
 	</div>
 
-	<div class="page" id="country-page">
+	<div class="page" id="campaign-page">
 		<header class='actionbar'>
 			<a class='back' data-page="welcome-page" href="#"> </a>
 			<h2>
@@ -181,7 +182,7 @@
 		</header>
 		<div class="content">
 			<h3><msg key='choose-campaign' /></h3>
-			<ul id="country-list"></ul>
+			<ul id="campaign-list"></ul>
 		</div>
 	</div>
 

--- a/assets/www/js/admintree.js
+++ b/assets/www/js/admintree.js
@@ -1,0 +1,50 @@
+define( [ 'jquery' ], function() {
+
+	function translateCode( code ) {
+		// TODO: i18n complete translations of code
+		var name = code;
+		if( CAMPAIGNS[ code ] ) {
+			name = CAMPAIGNS[ code ].desc;
+		}
+		return name;
+	}
+
+	function AdminLevel( code, parents ) {
+		this.code = code;
+		this.name = translateCode( code );
+		this.parents = parents;
+	}
+
+	function AdminTreeApi( base ) {
+		this.baseUrl = base;
+	}
+
+	AdminTreeApi.prototype = {
+		getLeaves: function( tree ) {
+			var data = { action: 'adminlevels', format: 'json' }, i;
+			if( tree ) {
+				for( i = 0; i < tree.length; i++ ) {
+					tree[ i ] = encodeURIComponent( tree[ i ] );
+				}
+				data.admtree = tree.join( '|' );
+			}
+			var d = $.ajax( {
+				url: this.baseUrl,
+				dataType: 'json',
+				data: data
+			} ).pipe( function( data ) {
+				var levels = data.admin_levels;
+				var adminLevels = [];
+				if( levels ) {
+					levels.forEach( function( item ) {
+						adminLevels.push( new AdminLevel( item.name, tree ) );
+					} );
+				}
+				return adminLevels;
+			} );
+			return d;
+		}
+	};
+
+	return AdminTreeApi;
+} );

--- a/assets/www/js/monuments.js
+++ b/assets/www/js/monuments.js
@@ -37,11 +37,14 @@ define([ 'jquery', 'monument' ], function( $, Monument ) {
 		});
 	};
 
-	MonumentsApi.prototype.getForAdminLevel = function( tree ) {
+	MonumentsApi.prototype.getForAdminLevel = function( tree, str ) {
 		var d = $.Deferred(), i,
 			data = { action: 'search' };
 		for( i = 0; i < tree.length; i++ ) {
 			data[ 'sradm' + i ] = tree[ i ];
+		}
+		if( str ) {
+			data.srname = '~' + str + '*';
 		}
 		return this.request( data );
 	};
@@ -75,13 +78,18 @@ define([ 'jquery', 'monument' ], function( $, Monument ) {
 		return [ minLon, minLat, maxLon, maxLat ];
 	};
 
-	MonumentsApi.prototype.getInBoundingBox = function(minLon, minLat, maxLon, maxLat) {
+	MonumentsApi.prototype.getInBoundingBox = function( minLon, minLat, maxLon, maxLat, str ) {
 		var bb = this.trimBoundingBox( minLon, minLat, maxLon, maxLat ),
-			bboxString = bb.join( ',' );
-		return this.request( {
-			action: 'search',
-			bbox: bboxString
-		} );
+			bboxString = bb.join( ',' ),
+			data = {
+				action: 'search',
+				bbox: bboxString
+			};
+		if( str ) {
+			data.srname = '~' + str + '*';
+		}
+		return this.request( data );
+		
 	};
 
 	return MonumentsApi;

--- a/assets/www/js/monuments.js
+++ b/assets/www/js/monuments.js
@@ -37,6 +37,16 @@ define([ 'jquery', 'monument' ], function( $, Monument ) {
 		});
 	};
 
+	MonumentsApi.prototype.getForAdminLevel = function( tree ) {
+		var d = $.Deferred(), i,
+			data = { action: 'search' };
+		for( i = 0; i < tree.length; i++ ) {
+			data[ 'sradm' + i ] = tree[ i ];
+		}
+		return this.request( data );
+	};
+	
+
 	MonumentsApi.prototype.filterByNameForCountry = function( country, str ) {
 		var d = $.Deferred();
 		return this.request( {

--- a/assets/www/messages/messages-en.properties
+++ b/assets/www/messages/messages-en.properties
@@ -62,7 +62,7 @@ change-photo=Change
 continue-upload=Continue
 skip-warning=Don't show this again
 
-no-monuments=No monuments to love in this country.
+no-monuments=Currently no monuments to love in this location. 
 tabbar-uploads=Uploads
 
 monument-sortby-heading=sort by

--- a/assets/www/test.html
+++ b/assets/www/test.html
@@ -23,5 +23,6 @@
 	<script src="test/js/api.js" type="text/javascript"></script>
 	<script src="test/js/monument.js" type="text/javascript"></script>
 	<script src="test/js/monuments.js" type="text/javascript"></script>
+	<script src="test/js/admintree.js" type="text/javascript"></script>
 </body>
 </html>

--- a/assets/www/test/fixtures.js
+++ b/assets/www/test/fixtures.js
@@ -41,7 +41,16 @@ $.ajax = function( options ) {
 		data = { query: '' };
 		return d.resolve( data );
 	} else if( options.url === 'http://toolserver.org/~erfgoed/api/api.php' ) {
-		if( options.success ) {
+		if ( options.data && options.data.action === 'adminlevels' ) {
+			if ( options.data.admtree === 'US|US-CA|Los%20Angeles%20County%2C%20California' ) {
+				d.resolve( { admin_levels: [ { name: 'ok' } ] } );
+			}
+		} else if( options.data.action === 'search' ) {
+			if ( options.data.sradm2 === 'San Francisco' &&
+				options.data.sradm1 === 'US-CA' && options.data.sradm0 === 'US' ) {
+				d.resolve( [ { country: 'us', id: 2, name: 'Golden Gate Bridge' } ] );
+			}
+		} else if ( options.success ) {
 			options.success( [] );
 		}
 	} else if( options.url === 'messages/messages-en.properties' ) {

--- a/assets/www/test/js/admintree.js
+++ b/assets/www/test/js/admintree.js
@@ -1,0 +1,12 @@
+(function() {
+
+module( 'admintree.js', {} );
+
+test( 'getLeaves', function() {
+	var tree = [ 'US', 'US-CA', 'Los Angeles County, California' ];
+	WLMMobile.admintree.getLeaves( tree ).done( function( data ) {
+		strictEqual( 'ok', data[ 0 ].name, 'the expected ajax request was created and data returned' );
+	} );
+});
+
+}());

--- a/assets/www/test/js/monuments.js
+++ b/assets/www/test/js/monuments.js
@@ -14,4 +14,10 @@ test( 'trimBoundingBox', function() {
 	strictEqual( bb2[ 3 ], 0.1,  'capped at 0.2 degrees width/height' );
 });
 
+test( 'getForAdminLevel', function() {
+	WLMMobile.monuments.getForAdminLevel( [ 'US', 'US-CA', 'San Francisco' ]).done( function( data ) {
+		strictEqual( data[ 0 ].name, 'Golden Gate Bridge' );
+	} );
+} );
+
 }());


### PR DESCRIPTION
Implements https://mingle.corp.wikimedia.org/projects/wlm_android_app/cards/114
Needs https://mingle.corp.wikimedia.org/projects/wlm_android_app/cards/143 (should probably fork off this branch)

exposes bugs:
https://bugzilla.wikimedia.org/show_bug.cgi?id=39109

Notes:
- tests
- repurpose country page as campaign page (rename template variables)
- add admintree js file
- tweak messages to be campaign specific rather than country specific
- alterations to back function to treat everything after the first / as data
  (Add TODO note to generalise the back and forward behaviour)
