### PR TITLE
fix geourls for android and safari (bug 38693)

### DIFF
--- a/assets/www/android/platform.js
+++ b/assets/www/android/platform.js
@@ -3,9 +3,10 @@ $('html').addClass('android');
 // Android opens a.external externally automatically.
 
 platform.geoUrl = function(lat, lon, address) {
-    var q = 'geo:' + lat + ',' + lon;
+	var latlng = lat + ',' + lon;
+	var q = 'geo:' + latlng;
     if (address) {
-        q += '?q=' + encodeURIComponent(address);
+		q += '?q=' + latlng + ' (' + encodeURIComponent( address ) + ')';
     }
     return q;
 }

--- a/assets/www/js/platform-stub.js
+++ b/assets/www/js/platform-stub.js
@@ -5,9 +5,9 @@ window.platform = {
 		// Google maps links for web & iOS
 		// on iOS these open in native Maps app
 		var url = ['http://maps.google.com/maps',
-			'?ll=', lat, ',', lon];
+			'?q=', lat, ',', lon ];
 		if(address) {
-			url.push('&q=' + encodeURIComponent(address));
+			url.push( '%20(' + encodeURIComponent( address ) + ')' );
 		}
 		return url.join('');
 	}


### PR DESCRIPTION
note: this reveals various monuments do not have longitude and latitude
coordinates

(note the diff looks weird as the original file used spaces instead of tabs for indents)
