### PR TITLE
fix broken test introduced by 400b815cf772a4c6e0ca2a8a4a9092c4c90e9685

### DIFF
--- a/assets/www/js/admintree.js
+++ b/assets/www/js/admintree.js
@@ -26,8 +26,8 @@ define( [ 'jquery' ], function() {
 				cacheKey = 'root', d = new $.Deferred();
 			if( tree ) {
 				for( i = 0; i < tree.length; i++ ) {
-					tree[ i ] = tree[ i ].replace( /\|/g, '\\|' ); // escape any pipes so as not to conflict with separators
-					admtree.push( tree[ i ] );
+					// escape any pipes so as not to conflict with separators
+					admtree.push( tree[ i ].replace( /\|/g, '\\|' ) );
 				}
 				admtree = admtree.join( '|' );
 				cacheKey = admtree;

--- a/assets/www/test/fixtures.js
+++ b/assets/www/test/fixtures.js
@@ -74,7 +74,7 @@ $.ajax = function( options ) {
 					{ name: '[[Alameda, California|Alameda]]' },
 					{ name: '[[Foo County, California]]' }
 				] } );
-			} else if( admintree === 'US|US-CA|[[Alameda, California|Alameda]]' ) {
+			} else if( admintree === 'US|US-CA|[[Alameda, California\\|Alameda]]' ) {
 				d.resolve( { admin_levels: [
 					{ name: '[[Alameda, California|Alameda]]' }
 				] } );
@@ -82,9 +82,9 @@ $.ajax = function( options ) {
 				d.resolve( { admin_levels: [
 					{ name: '[[Foo, California|Foo]]' }
 				] } );
-			} else if( admintree === 'US|US-CA|[[Foo County, California]]|[[Foo, California|Foo]]' ) {
+			} else if( admintree === 'US|US-CA|[[Foo County, California]]|[[Foo, California\\|Foo]]' ) {
 				d.resolve( { admin_levels: [] } );
-			} else if( admintree === 'US|US-CA|[[Alameda, California|Alameda]]|[[Alameda, California|Alameda]]' ) {
+			} else if( admintree === 'US|US-CA|[[Alameda, California\\|Alameda]]|[[Alameda, California\\|Alameda]]' ) {
 				d.resolve( { admin_levels: [] } );
 			} else if ( admintree === 'US|US-CA|Los Angeles County, California' ) {
 				d.resolve( { admin_levels: [ { name: 'ok' } ] } );


### PR DESCRIPTION
ensure we don't escape any pipes in admin tree - only escape when
passing to ajax request
update fixtures to take into account pipe in requests
hurray for tests \o/
