### PR TITLE
Stop escaping pipes in admintree names

### DIFF
--- a/assets/www/js/admintree.js
+++ b/assets/www/js/admintree.js
@@ -26,8 +26,7 @@ define( [ 'jquery' ], function() {
 				cacheKey = 'root', d = new $.Deferred();
 			if( tree ) {
 				for( i = 0; i < tree.length; i++ ) {
-					// escape any pipes so as not to conflict with separators
-					admtree.push( tree[ i ].replace( /\|/g, '\\|' ) );
+					admtree.push( tree[ i ] );
 				}
 				admtree = admtree.join( '|' );
 				cacheKey = admtree;


### PR DESCRIPTION
I updated the API to handle this for you - which makes the API
more friendly to current API users and also makes the escaping
headache in the app a little less severe than it already is.
The API now automagically knows the difference between a | used
for separating adm levels and a | inside of wikitext.
As such, this has a dependency on r862 getting deployed to the
API servers.
