### PR TITLE
remove broken link to 'country page' (bug 39249)

### DIFF
--- a/assets/www/index.html
+++ b/assets/www/index.html
@@ -224,7 +224,6 @@
 				</select>
 			</h2>
 			<a class="show-search"><img src='images/2-action-search.png' /></a>
-			<a class='page-link' data-page='country-page'><img src='images/7-location-place.png' /></a>
 			<a class='page-link' data-page='settings-page'><img src='images/2-action-settings.png' /></a>
 		</header>
 		<header class='actionbar hidden searchbar'>
@@ -249,7 +248,6 @@
 					<option value="results-page" data-msg-text="dropdown-list-view"></option>
 				</select>
 			</h2>
-			<a class='page-link' data-page='country-page'><img src='images/7-location-place.png' /></a>
 			<a class='page-link' data-page='settings-page'><img src='images/2-action-settings.png' /></a>
 		</header>
 		<div class="content" id="map"></div>
@@ -264,7 +262,6 @@
 				<option value="incomplete-view" data-msg-text="uploads-incomplete"></option>
 			</select>
 			</h2>
-			<a class='page-link' data-page='country-page'><img src='images/7-location-place.png' /></a>
 			<a class='page-link' data-page='settings-page'><img src='images/2-action-settings.png' /></a>
 		</header>
 		<div class="content">


### PR DESCRIPTION
this could point to the home page or the list of campaigns (country level)
page. Since the icon looks like a map I think this needs more thought to
I'm removing for time being
