### PR TITLE
enable method for continuing results

### DIFF
--- a/assets/www/app.css
+++ b/assets/www/app.css
@@ -20,6 +20,7 @@ body {
 }
 
 /* spinner related styles */
+#results .footer.loading,
 .loading #results,
 .loading .content {
 	background-image: url(images/loader.gif);
@@ -38,6 +39,10 @@ body {
 
 .loading#results-page .content {
 	background: none;
+}
+
+#results.incomplete {
+	border-bottom: dotted 10px #ccc;
 }
 
 a {

--- a/assets/www/js/app.js
+++ b/assets/www/js/app.js
@@ -275,6 +275,30 @@ require( [ 'jquery', 'l10n', 'geo', 'api', 'templates', 'monuments', 'monument',
 	}
 
 	function showMonumentsList(monuments) {
+
+		var infiniteScrollAjax;
+		function infiniteScroll() {
+			var footer = $( '#results .footer' )[ 0 ];
+			if( footer && monuments.next ) {
+				$( footer ).addClass( 'loading' );
+				if ( infiniteScrollAjax ) {
+					return;
+				} else {
+					infiniteScrollAjax = monuments.next().done( function( newMonuments ) {
+						$( footer ).removeClass( 'loading' );
+						var m = monuments.concat( newMonuments );
+						m.next = newMonuments.next;
+						showMonumentsList( m );
+						infiniteScrollAjax = false;
+					} ).error( function() {
+						infiniteScrollAjax = false;
+					} );
+				}
+			}
+		}
+		// setup scroll to bottom
+		$( '#results' ).unbind( 'hit-bottom' ).bind( 'hit-bottom', infiniteScroll );
+
 		$( '#results' ).empty();
 		var monumentTemplate = templates.getTemplate('monument-list-item-template');	
 		var listThumbFetcher = commonsApi.getImageFetcher(64, 64);
@@ -331,6 +355,14 @@ require( [ 'jquery', 'l10n', 'geo', 'api', 'templates', 'monuments', 'monument',
 		listThumbFetcher.send();
 
 		$( "#results" ).data( 'monuments', monuments );
+		// if next property is set then there are more results so allow access to them
+		// bear in mind some results may be hidden due to not having a valid campaign in campaigns-data.js so check monument length
+		if ( monuments.next && currentSortMethod !== 'distance' && monuments.length > 0 ) {
+			$( '#results' ).addClass( 'incomplete' );
+			$( '<li class="footer"></li>' ).appendTo( '#results' );
+		} else {
+			$( '#results' ).removeClass( 'incomplete' );
+		}
 		$("#monuments-list").show();
 	}
 
@@ -1036,6 +1068,14 @@ require( [ 'jquery', 'l10n', 'geo', 'api', 'templates', 'monuments', 'monument',
 
 		// Everything has been initialized, so let's show them the UI!
 		$( 'body' ).removeClass( 'hidden' );
+
+		$( window ).scroll( function() {
+			var max = $( document.body ).height() + $( document.body ).scrollTop();
+			var threshold = 50;
+			if ( document.body.scrollHeight > max - threshold ) {
+				$( '#results' ).trigger( 'hit-bottom' );
+			}
+		} );
 	}
 
 	l10n.init().done( function() {

--- a/assets/www/js/monuments.js
+++ b/assets/www/js/monuments.js
@@ -6,13 +6,26 @@ define([ 'jquery', 'monument' ], function( $, Monument ) {
 	}
 
 	MonumentsApi.prototype.request = function( params ) {
-		var that = this;
-		
+		var that = this, options = {};
+
 		console.log(this.url + ' : ' + JSON.stringify(params));
+
+		// attaches a function to array to query for next set of results
+		// TODO: is there a better way that doesn't rely on an unknown property?
+		function addPointer( monuments, srcontinue ) {
+			var newOptions = $.extend( {}, options );
+			newOptions.data = options.data || {};
+			newOptions.data.srcontinue = srcontinue;
+			monuments.next = function() {
+				console.log( 'run continuing request with srcontinue=' + srcontinue );
+				return $.ajax( newOptions );
+			};
+			return monuments;
+		}
 
 		// Force JSON
 		params.format = 'json';
-		return $.ajax({
+		options = {
 			url: this.url,
 			data: params,
 			dataType: 'text',
@@ -34,9 +47,13 @@ define([ 'jquery', 'monument' ], function( $, Monument ) {
 						console.log( 'the campaign ' + m.country + ' is not currently supported by app so throwing away ' + m.name );
 					}
 				});
+				if ( data.hasOwnProperty( 'continue' ) ) {
+					monuments = addPointer( monuments,  data[ 'continue' ].srcontinue );
+				}
 				return monuments;
 			}
-		});
+		};
+		return $.ajax( options );
 	};
 
 	MonumentsApi.prototype.getForCountry = function( country ) {


### PR DESCRIPTION
when the bottom of the page is scrolled to it will retrieve the next
set of results
- for ajax results that go through monuments api that can be continued set next property on array
- add list item at end of the list to signal it is possible to continue
  *\* add dotted border bottom to suggest the list is unfinished
- when locating new monuments show ajax loader
- prevent multiple attempts to load new monuments by checking for an existing query
