### PR TITLE
respect back button presses when dealing with campaign pages (bug 39575)

### DIFF
--- a/assets/www/js/app.js
+++ b/assets/www/js/app.js
@@ -835,7 +835,9 @@ require( [ 'jquery', 'l10n', 'geo', 'api', 'templates', 'monuments', 'monument',
 		showPage( pageName, d );
 
 		d.done( function( campaigns ) {
-			if( campaigns.length === 0 ) {
+			if ( getCurrentPage() !== pageName ) { // the user pressed back so abort any further changes
+				console.log( 'silently dying due to a back button press' );
+			} else if ( campaigns.length === 0 ) {
 				goBack(); // kill the last campaign page request (seems hacky...)
 				listMonuments( campaignTree );
 			} else {


### PR DESCRIPTION
if a user clicks a sub campaign and a request for monuments is made and
user clicks back ensure that they are not redirected to the monuments page
when the deferred object is resolved
