### PR TITLE
Bug 38290 partial: save newly taken photos to photo gallery

### DIFF
--- a/assets/www/js/app.js
+++ b/assets/www/js/app.js
@@ -1278,7 +1278,8 @@ require( [ 'jquery', 'l10n', 'geo', 'api', 'templates', 'monuments', 'monument',
 				// Do nothing.
 			}, {
 				// options
-				destinationType: Camera.DestinationType.FILE_URI
+				destinationType: Camera.DestinationType.FILE_URI,
+				saveToPhotoAlbum: true
 			});
 		});
 		$('#selectphoto').click(function() {


### PR DESCRIPTION
On at least some devices, the Gallery app won't see changes until you remount the SD card or reboot.
This is an upstream bug which was supposed to be fixed in Cordova 1.9.0 but doesn't seem fixed for me in 2.0.0.

https://issues.apache.org/jira/browse/CB-924
