### PR TITLE
Bug 39571: truncate long filenames

### DIFF
--- a/assets/www/js/monument.js
+++ b/assets/www/js/monument.js
@@ -33,11 +33,38 @@ define( [ 'jquery', 'utils' ], function() {
 	};
 
 	Monument.prototype.generateFilename = function( date ) {
+		var maxLength = 240; // 240 bytes maximum enforced by MediaWiki
+		maxLength = maxLength / 2 - '/1024px-'.length; // halve space due to current bugs with Swift causing thumbnails to fail
+
 		var name = this.name.replace( String.fromCharCode(27), '-' );
+		name = name.replace( /[\x7f\.\[#<>\[\]\|\{\}/:]/g, '-' );
+
 		var d = date || new Date();
-		var months = [ 'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sept', 'Oct', 'Nov', 'Dec' ];
-		var suffix =  d.getDate() + months[ d.getMonth() ] + d.getFullYear() + ' ' + d.getHours() + 'hrs' + d.getMinutes() + 'mins' + d.getSeconds() + 'secs';
-		return name.replace( /[\x7f\.\[#<>\[\]\|\{\}]/g, '-' ) + ' (taken on ' + suffix + ').jpg';
+		function pad( str, len ) {
+			if ( typeof str !== 'string' ) {
+				str = str + '';
+			}
+			while ( str.length < len ) {
+				str = '0' + str;
+			}
+			return str;
+		}
+		var suffix = ' ' +
+			pad( d.getFullYear(), 4 ) +
+			'-' +
+			pad( d.getMonth(), 2 ) +
+			'-' +
+			pad( d.getDate(), 2 ) +
+			' ' +
+			pad( d.getHours(), 2 ) +
+			'-' +
+			pad( d.getMinutes(), 2 ) +
+			'-' +
+			pad( d.getSeconds(), 2 ) +
+			'.jpg';
+
+		var allowedLength = maxLength - suffix.length;
+		return trimUtf8String( name, allowedLength ) + suffix;
 	};
 	
 	Monument.prototype.processArticleLink = function() {

--- a/assets/www/js/utils.js
+++ b/assets/www/js/utils.js
@@ -5,3 +5,43 @@ function stripWikiText( str ) {
 	str = str.replace( /\{\{([^\]]+)\}\}/g, '' );
 	return str;
 }
+
+function trimUtf8String( str, allowedLength ) {
+	// Count UTF-8 bytes to see where we need to crop long names.
+	var bytes = 0, chars = 0;
+	var codeUnit, len;
+
+	for ( var i = 0; i < str.length; i++ ) {
+		// JavaScript strings are UTF-16.
+		codeUnit = str.charCodeAt( i );
+
+		// http://en.wikipedia.org/wiki/UTF-8#Description
+		if ( codeUnit < 0x80 ) {
+			len = 1;
+		} else if ( codeUnit < 0x800 ) {
+			len = 2;
+		} else if ( codeUnit >= 0xd800 && codeUnit < 0xe000 ) {
+			// http://en.wikipedia.org/wiki/UTF-16#Description
+			// Code point is one half of a surrogate pair.
+			// This and its partner combine to form a single 4 byte character in UTF-8.
+			len = 4;
+		} else {
+			len = 3;
+		}
+		if ( bytes + len <= allowedLength ) {
+			bytes += len;
+			chars++;
+			if ( len == 4 ) {
+				// Skip over second half of surrogate pair as a unit.
+				chars++;
+				i++;
+			}
+		} else {
+			// Ran out of bytes.
+			return str.substr( 0, chars );
+		}
+	}
+
+	// We fit!
+	return str;
+}

--- a/assets/www/test/js/monument.js
+++ b/assets/www/test/js/monument.js
@@ -7,23 +7,28 @@ test( 'generateFilename: . symbol', function() {
 		lat: 4, lon: 4, name: 'hello . symbol', address: '29 Acacier Road'
 	}, m, m2, m3, m4,
 	name, name2, name3, name4;
-	
+
 	m = new WLMMobile.Monument( data );
 	data.name = 'hello' + String.fromCharCode(27)+'?';
 	m2 = new WLMMobile.Monument( data );
 	data.name = '[hello]';
 	m3 = new WLMMobile.Monument( data );
-	data.name = '#evil<name>[muh]h|a{hhh}'
+	data.name = '#evil<name>[muh]h|a{hhh}oh:no/mr.bill'
 	m4 = new WLMMobile.Monument( data );
+	data.name = 'Аўгустоўскі канал:водны шлях, які ўключае зарэгуляваны ўчастак р. Чорная Ганча ад Дзяржаўнай граніцы з Рэспублікай Польшча да в. Сонічы (13км), штучны ўчастак канала ад в. Сонічы да шлюза«Нямнова» (6,5 км)гідравузел «Нямнова»: Гарадзенскі раён. Тэрыторыя ў межах матэрыяльнай нерухомайгісторыка-культурнай каштоўнасьці, устаноўленых праектам «Зоны аховы і рэжымыіх утрыманьня гісторыка-культурнай каштоўнасьці «Аўгустоўскі канал»';
+	m5 = new WLMMobile.Monument( data );
 
 	name = m.generateFilename();
 	name2 = m2.generateFilename();
 	name3 = m3.generateFilename();
 	name4 = m4.generateFilename();
+	name5 = m5.generateFilename();
 	strictEqual( name.indexOf( 'hello - symbol' ), 0, 'the illegal symbol was escaped' );
 	strictEqual( name2.indexOf( 'hello-?' ), 0, 'the illegal symbol was escaped' );
 	strictEqual( name3.indexOf( '-hello-' ), 0, 'the illegal symbol was escaped' );
-	strictEqual( name4.indexOf( '-evil-name--muh-h-a-hhh-' ), 0, 'the illegal symbols were escaped' );
+	strictEqual( name4.indexOf( '-evil-name--muh-h-a-hhh-oh-no-mr-bill' ), 0, 'the illegal symbols were escaped' );
+	ok( name5.length < 240, 'long filenames are truncated with room to under 240 chars' ); // warning: actual limit lowered due to thumbnail problems
+	strictEqual( name5.length, 71, 'long filenames are truncated for utf-8' ); // ideally this would convert to utf-8 and check the buffer length :)
 });
 
 test( 'randomness of monument names', function() {

--- a/assets/www/test/js/utils.js
+++ b/assets/www/test/js/utils.js
@@ -4,3 +4,11 @@ test( 'stripWikiText', function() {
 	strictEqual( stripWikiText( '[[San Francisco County, California]]' ), 'San Francisco County' );
 	strictEqual( stripWikiText( '[[Blah|Test]]' ), 'Test' );
 } );
+
+test( 'trimUtf8String', function() {
+	strictEqual( trimUtf8String( 'Just a string', 20 ), 'Just a string', 'ascii string fits' );
+	strictEqual( trimUtf8String( 'Just a string', 10 ), 'Just a str', 'ascii string truncated' );
+	strictEqual( trimUtf8String( 'Júst á stríng', 10 ), 'Júst á s', 'latin1 string truncated' );
+	strictEqual( trimUtf8String( 'こんにちは', 10 ), 'こんに', 'CJK string truncated' );
+	strictEqual( trimUtf8String( '𐌰𐌱𐌲𐌳', 10 ), '𐌰𐌱', 'non-BMP string truncated' );
+} );


### PR DESCRIPTION
- strip more evil chars
- changes filename format to "[truncated filtered name] DD-MM-YY HH-MM-SS.jpg"
- truncates to fit filenames in 240 UTF-8 bytes, cut in half, with extra wiggle room for thumb stuff

Includes a test case with a super long monument name from Belarus.
