### PR TITLE
hide preamble text for error handler when a clearer message is available...

### DIFF
--- a/assets/www/index.html
+++ b/assets/www/index.html
@@ -462,7 +462,7 @@
 					<h2><msg key="failure-heading" /></h2>
 				</header>
 				<div class="content">
-					<p>
+					<p class="generic-error-msg">
 						<msg key="failure-details">
 					</p>
 					<div class="error-information"></div>

--- a/assets/www/js/app.js
+++ b/assets/www/js/app.js
@@ -483,11 +483,17 @@ require( [ 'jquery', 'l10n', 'geo', 'api', 'templates', 'monuments', 'monument',
 		addMonuments( monumentList );
 	}
 
-	function displayError( heading, text ) {
+	function displayError( heading, text, hidePreamble ) {
 		showPage( 'error-page' );
 		var info = $( '.error-information' ).empty()[ 0 ];
+		var $preamble = $( '#error-page .generic-error-msg' );
 		$( '<h3 />' ).text( heading ).appendTo( info );
 		$( '<p />' ).html( text ).appendTo( info );
+		if ( hidePreamble ) {
+			$preamble.hide();
+		} else {
+			$preamble.show();
+		}
 		return info;
 	}
 
@@ -753,7 +759,7 @@ require( [ 'jquery', 'l10n', 'geo', 'api', 'templates', 'monuments', 'monument',
 							break;
 					}
 					$( "#login-status-message" ).empty();
-					displayError( mw.msg( 'login-failed'), errMsg );
+					displayError( mw.msg( 'login-failed'), errMsg, errMsg ? true : false );
 					fail( status );
 				}
 			}).fail( function( err, textStatus ) {


### PR DESCRIPTION
... (bug 39638)

when invoking the error message popup allow the invoker to hide the generic text
"We just broke something we shouldn't have"

STORY https://mingle.corp.wikimedia.org/projects/wlm_android_app/cards/196
