### PR TITLE
ensure if marking a list as incomplete it is not empty

### DIFF
--- a/assets/www/js/app.js
+++ b/assets/www/js/app.js
@@ -417,7 +417,7 @@ require( [ 'jquery', 'l10n', 'geo', 'api', 'templates', 'monuments', 'monument',
 
 		$( "#results" ).data( 'monuments', monuments );
 		// if next property is set then there are more results so allow access to them
-		if ( monuments.next && currentSortMethod !== 'distance' ) {
+		if ( monuments.next && monuments.length > 0 && currentSortMethod !== 'distance' ) {
 			$( '#results' ).addClass( 'incomplete' );
 			$( '<li class="footer"></li>' ).appendTo( '#results' );
 		} else {


### PR DESCRIPTION
some monuments are filtered out due to missing campaign data
(see bug 39568) take this into account
