### PR TITLE
Tweak ImageFetcher to reject the deferred if we are given a thumb URL bu...

### DIFF
--- a/assets/www/js/api.js
+++ b/assets/www/js/api.js
@@ -296,6 +296,11 @@ define(['jquery'], function() {
 							$img = $( img );
 						$img.attr( 'src', imageinfo.thumburl ).one( 'load', function() {
 							deferred.resolve( imageinfo );
+							$img.unbind( 'error' );
+						} ).one( 'error', function() {
+							// Image failed to load -- such as broken thumbnail or 404.
+							deferred.reject();
+							$img.unbind( 'load' );
 						} );
 					} else {
 						console.log( 'Failed to locate deferred image with title ' + title );


### PR DESCRIPTION
...t cannot load it

This may help with some of the 'spinner goes forever' issues, eg with images where the thumbs don't generate properly because the filename was too long.
