### PR TITLE
fix search to be more useful

### DIFF
--- a/assets/www/js/app.js
+++ b/assets/www/js/app.js
@@ -205,8 +205,8 @@ require( [ 'jquery', 'l10n', 'geo', 'api', 'templates', 'monuments', 'monument',
 
 	function showMonumentDetail(monument) {
 		var monumentTemplate = templates.getTemplate('monument-details-template');
+		 // @FIXME remove dependency on CAMPAIGNS[monument.country].desc
 		var imageFetcher = commonsApi.getImageFetcher(300, 240);
-		// @FIXME remove dependency on CAMPAIGNS[monument.country].desc
 		var campaign = CAMPAIGNS[ monument.country ] ? CAMPAIGNS[ monument.country ].desc : monument.country;
 		var $monumentDetail = $( monumentTemplate( { monument: monument, campaign: campaign } ) );
 		$("#monument-detail").html($monumentDetail).localize();
@@ -1211,18 +1211,11 @@ require( [ 'jquery', 'l10n', 'geo', 'api', 'templates', 'monuments', 'monument',
 			}
 
 			monumentSearchTimeout = window.setTimeout( function() {
-				var args = [].concat( getCurrentBoundingBox() ),
-					campaign = getCurrentCampaign();
+				var campaign = getCurrentCampaign();
 				$("#results").empty();
-				args.push( value );
 
-				if ( args.length === 5 ) {
-					console.log( 'searching with bounding box: ' + args.join( ',' ) );
-					monumentSearchReq = monuments.getInBoundingBox.apply( monuments, args );
-				} else {
-					console.log( 'searching with campaign ' + campaign.join( ',' ) );
-					monumentSearchReq = monuments.getForAdminLevel( campaign, value );
-				}
+				console.log( 'searching with campaign ' + campaign.join( ',' ) );
+				monumentSearchReq = monuments.getForAdminLevel( campaign, value );
 
 				monumentSearchReq.done( function( monuments ) {
 					showMonumentsList( monuments );


### PR DESCRIPTION
currently if you have given your location a bounding box is set and
all searches from the list view are now based on that bounding box

it's actually more easy to ignore this. If campaign is set it will
search within that campaign. If not it will search across the whole
api for monuments. I think this is much more useful and aids discovery
