### PR TITLE
correct month in filename

### DIFF
--- a/assets/www/js/monument.js
+++ b/assets/www/js/monument.js
@@ -52,7 +52,7 @@ define( [ 'jquery', 'utils' ], function() {
 		var suffix = ' ' +
 			pad( d.getFullYear(), 4 ) +
 			'-' +
-			pad( d.getMonth(), 2 ) +
+			pad( d.getMonth() + 1, 2 ) +
 			'-' +
 			pad( d.getDate(), 2 ) +
 			' ' +


### PR DESCRIPTION
timestamp is incorrect getMonth returns the month number where january
is 0 :)
