### PR TITLE
Mark camera and location features as optional in the manifest.

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -18,6 +18,12 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />   
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
+    <!-- Mark optional features to avoid excluding devices from Google Play store -->
+    <uses-feature android:name="android.hardware.camera" android:required="false" />
+    <uses-feature android:name="android.hardware.camera.autofocus" android:required="false" />
+    <uses-feature android:name="android.hardware.location" android:required="false" />
+    <uses-feature android:name="android.hardware.location.network" android:required="false" />
+    <uses-feature android:name="android.hardware.location.gps" android:required="false" />
 
     <application android:icon="@drawable/ic_launcher" android:label="@string/app_name"
         android:debuggable="true">


### PR DESCRIPTION
Should help with devices listing the app as incompatible in the Google Play store, though I can't test without actually pushing it to the store. :P

Camera is optional because we can pull from your gallery, which might be synced with other sources.
Also "camera" means "front-facing camera". :P
Location services are optional as well, and the app should function without them.
