### PR TITLE
dynamically load campaign data (Bug 39847)

### DIFF
--- a/assets/www/js/app.js
+++ b/assets/www/js/app.js
@@ -21,7 +21,7 @@ function handleOpenURL(url)
 */
 require( [ 'jquery', 'l10n', 'geo', 'api', 'templates', 'monuments', 'monument', 'preferences', 'database', 'admintree', 'photo',
 		'page-uploads',
-		'jquery.localize', 'campaigns-data', 'licenses-data', 'utils' ],
+		'jquery.localize', 'campaigns-data', 'campaign-loader', 'licenses-data', 'utils' ],
 	function( $, l10n, geo, Api, templates, MonumentsApi, Monument, prefs, db, AdminTreeApi, Photo, UploadPage ) {
 
 	var api = new Api( WLMConfig.WIKI_API, {

--- a/assets/www/js/campaign-loader.js
+++ b/assets/www/js/campaign-loader.js
@@ -1,0 +1,74 @@
+(function() {
+	var names = {}, campaigns = {},
+		cacheData = localStorage.getItem( 'wlm-campaign-data' );
+
+	names.ad = 'Andorra'
+	names.at = 'Austria'
+	names['be-bru'] = 'Belgium (Brussels)'
+	names['be-vlg'] = 'Belgium (Flanders)'
+	names['be-wal'] = 'Belgium (Wallonia)'
+	names.by = 'Belarus'
+	names.ch = 'Switzerland'
+	names['de-by'] = 'Germany (Bavaria)'
+	names['de-he'] = 'Germany (Hesse)'
+	names['de-nrw-bm'] = 'Germany (nrw-bm)'
+	names['de-nrw-k'] = 'Germany (nrw-k)'
+	names['dk-bygning'] = 'Denmark (bygning)'
+	names['dk-fortids'] = 'Denmark (fortids)'
+	names.ee = 'Estonia'
+	names.es = 'Spain'
+	names['es-ct'] = 'Spain (Catalonia)'
+	names['es-vc'] = 'Spain (Valencia)'
+	names.fr = 'France'
+	names.ie = 'Ireland'
+	names['it-88'] = 'Italy (88)'
+	names['it-bz'] = 'Italy (bz)'
+	names.lu = 'Luxemburg'
+	names.mt = 'Malta'
+	names.nl = 'Netherlands'
+	names.no = 'Norway'
+	names.pl = 'Poland'
+	names.pt = 'Portugal'
+	names.ro = 'Romania'
+	names.se = 'Sweden'
+	names.sk = 'Slovakia'
+	names.us = 'United States'
+	names.pa = 'Panama'
+	names['us-ca'] = 'California, United States'
+	names.cl = 'Chile'
+	names.rs = 'Serbia'
+	names.il = 'Israel'
+	names.ca = 'Canada'
+	names.in = 'India'
+	names.gh = 'Ghana'
+	names.ar = 'Argentina'
+	names.mx = 'Mexico'
+	names.co = 'Colombia'
+	names.cz = 'Czech Republic'
+
+	if ( cacheData ) {
+		console.log( 'loading live campaign data from cache' );
+		window.CAMPAIGNS = JSON.parse( cacheData );
+	}
+	// update cache with latest and greatest
+	$.ajax( { dataType: 'json',
+		url: 'http://commons.wikimedia.org/w/api.php?action=uploadcampaign&format=json&ucprop=config'
+	} ).done( function( data ) {
+		var campdata, camp, i;
+		if ( data.uploadcampaign && data.uploadcampaign.campaigns ) {
+			campdata = data.uploadcampaign.campaigns;
+			for ( i = 0; i < campdata.length; i++ ) {
+				camp = campdata[ i ];
+				if ( camp.name.indexOf( 'wlm-' ) === 0 && camp.isenabled === 1 ) {
+					code = camp.name.replace( 'wlm-', '' );
+					camp.desc = names[ code ] || code;
+					campaigns[ code ] = camp;
+				}
+			}
+			console.log( 'campaign data refreshed in cache' );
+			window.CAMPAIGNS = campaigns;
+			localStorage.setItem( 'wlm-campaign-data', JSON.stringify( campaigns ) ); // cache for next time
+		}
+	});
+}() );
+


### PR DESCRIPTION
this emulates the python script to load campaign data dynamically
and update window.CAMPAIGNS
the result is cached in local storage and loaded on future loads
this runs every time the app loads for the first time meaning it doesn't
disrupt the user
campaign-data.js is kept so there is always a fallback.

note: we should probably use node to generate campaigns-data.js to
avoid duplication
