### PR TITLE
Bug 40011: strip bold/italic apostrophe markup from wikitext fields

### DIFF
--- a/assets/www/js/utils.js
+++ b/assets/www/js/utils.js
@@ -3,6 +3,8 @@ function stripWikiText( str ) {
 	str = str.replace( /^\[\[(.*),(.*)\]\]$/, '$1' );
 	str = str.replace( /\[\[([^\]]+)\]\]/g, '$1' );
 	str = str.replace( /\{\{([^\]]+)\}\}/g, '' );
+	str = str.replace( /'''(.*?)'''/g, '$1' );
+	str = str.replace( /''(.*?)''/g, '$1' );
 	return str;
 }
 

--- a/assets/www/test/js/utils.js
+++ b/assets/www/test/js/utils.js
@@ -3,6 +3,9 @@ test( 'stripWikiText', function() {
 	strictEqual( stripWikiText( '[[District of Columbia]]' ), 'District of Columbia' );
 	strictEqual( stripWikiText( '[[San Francisco County, California]]' ), 'San Francisco County' );
 	strictEqual( stripWikiText( '[[Blah|Test]]' ), 'Test' );
+	strictEqual( stripWikiText( "[[Star of India (ship)|''Star of India'']]" ), 'Star of India' );
+	strictEqual( stripWikiText( "[[Star of India (ship)|'''Star of India''']]" ), 'Star of India' );
+	strictEqual( stripWikiText( "[[Star of India (ship)|'''''Star of India''''']]" ), 'Star of India' );
 } );
 
 test( 'trimUtf8String', function() {


### PR DESCRIPTION
https://bugzilla.wikimedia.org/show_bug.cgi?id=40011
