### PR TITLE
'Upload more of this monument' link on description page

### DIFF
--- a/assets/www/index.html
+++ b/assets/www/index.html
@@ -166,6 +166,8 @@
 |other_fields=
 }}
 
+[//commons.wikimedia.org/wiki/Special:UploadWizard?campaign=wlm-<%= encodeURIComponent(descData.monument.country) %>&id=<%= encodeURIComponent(descData.monument.id) %> <%= mw.message('upload-more-link') %>]
+
 =={{int:license-header}}==
 {{self|<%= descData.license %>}}
 

--- a/assets/www/messages/messages-en.properties
+++ b/assets/www/messages/messages-en.properties
@@ -146,6 +146,8 @@ placeholder-username=Username
 placeholder-password=Password
 settings-user-name=You are <strong>$1</strong>!
 
+upload-more-link=Upload more photos of this monument
+
 about=About this game
 about-wlm-p1=<p><a href="$1">Wiki Loves Monuments</a> is the exciting international photo contest for monuments in which you can participate. It is organised by Wikimedia, the movement behind a little encyclopedia you might have heard of called <a href="$2">Wikipedia</a>.</p><p>Cultural heritage is an important part of the knowledge that Wikipedia strives to share with the world.</p><p>You can help its growth by contributing photos of monuments in your area using this easy to use mobile application.</p>
 about-app-header=Version Information

--- a/assets/www/messages/messages-qqq.properties
+++ b/assets/www/messages/messages-qqq.properties
@@ -130,6 +130,7 @@ settings-logout=Label for log out button.
 placeholder-username=Prompt for username in login screen.
 placeholder-password=Prompt for password in login screen.
 settings-user-name=Informational HTML text on the settings screen after logging in. $1 is current wiki username.
+upload-more-link=Link text inserted into description pages that sends user to UploadWizard with appropriate parameters to upload more photos of the same monument on the desktop.
 about=Heading for the about page.
 about-wlm-p1=An HTML/text string that describes the game.
 about-app-header=Information about the app itself


### PR DESCRIPTION
Allows visitors to the image page to easily upload more photos of the same monument by linking to UploadWizard with the appropriate campaign and ID parameters.
