### PR TITLE
avoid error by not clearing watch when id is undefined

### DIFF
--- a/assets/www/js/app.js
+++ b/assets/www/js/app.js
@@ -185,7 +185,9 @@ require( [ 'jquery', 'l10n', 'geo', 'api', 'templates', 'monuments', 'monument',
 		}
 		// special casing for specific pages
 		// TODO: provide generic mechanism for this
-		navigator.geolocation.clearWatch( watchId );
+		if ( watchId ) {
+			navigator.geolocation.clearWatch( watchId );
+		}
 		var monuments = $( "#results" ).data( 'monuments' );
 		if( monuments && pageName === 'results-page' ) {
 			showMonumentsList( monuments );


### PR DESCRIPTION
The first time through I was getting `Cannot read property 'intervalId' of undefined` because `watchId` is not defined yet. There's no need to call `clearWatch` if there is no watch.
