### PR TITLE
change MONUMENT_API to new URL to avoid redirect garbling URL parameter

### DIFF
--- a/assets/www/js/config.js
+++ b/assets/www/js/config.js
@@ -2,7 +2,7 @@ var WLMConfig = {
 	BLOCKING_POLICY: 'http://commons.wikimedia.org/wiki/Commons:Blocking_policy?uselang=$1',
 	COMMONS_API: 'https://commons.wikimedia.org/w/api.php',
 	GITHUB_MESSAGES: 'https://raw.github.com/wikimedia/WLMMobile/master/assets/www/',
-	MONUMENT_API: 'http://wlm.wikimedia.org/api/api.php',
+	MONUMENT_API: 'http://toolserver.org/~erfgoed/api/api.php',
 	MONUMENT_SEARCH_LIMIT: 50, // amount of monuments to request in a single query (see bug 39182 for more context)
 	SIGNUP_PAGE: 'https://commons.wikimedia.org/w/index.php?title=Special:UserLogin&type=signup&uselang=$1',
 	WIKI_API: 'https://test.wikipedia.org/w/api.php',


### PR DESCRIPTION
`MONUMENT_API` is set to `http://wlm.wikimedia.org/api/api.php`, which redirects to `http://toolserver.org/~erfgoed/api/api.php` now. Unfortunately the redirect reescapes the URL parameters, so the commas are changed from `%2C` to `%252C` and then don't get unescaped properly, so the search returns an error in JSON instead of results.

This patch changes the URL to avoid the redirect. 
